### PR TITLE
AlbumCollection Cell의 포커싱 효과를 이용해 UX 개선

### DIFF
--- a/rabit/rabit/Album/AlbumViewController.swift
+++ b/rabit/rabit/Album/AlbumViewController.swift
@@ -62,11 +62,13 @@ private extension AlbumViewController {
     func setupAlbumCollectionView() {
         let layout = CompositionalLayoutFactory.shared.create(
             widthFraction: 1.0,
-            heightFraction: 0.5,
+            heightFraction: 0.32,
+            groupWidthFraction: 0.65,
             requireHeader: true,
             headerWidth: UIScreen.main.bounds.width,
             headerHeight: 50.0,
-            enableScrolling: true
+            enableScrolling: true,
+            sectionHandler: getFocusedCellIndex
         )
 
         albumCollectionView.collectionViewLayout = layout
@@ -129,5 +131,24 @@ private extension AlbumViewController {
         albumCollectionView.rx.modelSelected(Album.Item.self)
             .bind(to: viewModel.photoSelected)
             .disposed(by: disposeBag)
+    }
+
+    func getFocusedCellIndex(
+        items: [NSCollectionLayoutVisibleItem],
+        offset: CGPoint,
+        environment: NSCollectionLayoutEnvironment
+    ) {
+        items.forEach { item in
+            guard item.representedElementKind != UICollectionView.elementKindSectionHeader else { return }
+
+            let cellWidth = environment.container.contentSize.width
+            let distanceFromCenter = abs((item.frame.midX - offset.x) - cellWidth / 2.0)
+
+            let minScale: CGFloat = 0.7
+            let maxScale: CGFloat = 1.0
+            let scale = max(maxScale - (distanceFromCenter / cellWidth), minScale)
+
+            item.transform = CGAffineTransform(scaleX: scale, y: scale)
+        }
     }
 }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -34,8 +34,8 @@ private extension AlbumCell {
         addSubview(thumbnailPictureView)
 
         thumbnailPictureView.snp.makeConstraints { make in
-            make.top.leading.equalTo(self).offset(10)
-            make.bottom.trailing.equalTo(self).inset(10)
+            make.top.leading.equalToSuperview().offset(10)
+            make.bottom.trailing.equalToSuperview().inset(10)
         }
     }
 }

--- a/rabit/rabit/Common/Factory/CompositionalLayoutFactory.swift
+++ b/rabit/rabit/Common/Factory/CompositionalLayoutFactory.swift
@@ -28,26 +28,30 @@ final class CompositionalLayoutFactory {
     func create(widthFraction: CGFloat,
                 heightFraction: CGFloat,
                 spacing: Spacing = Spacing(),
+                groupWidthFraction: CGFloat = 1.0,
                 requireHeader: Bool = false,
                 headerWidth: CGFloat = .zero,
                 headerHeight: CGFloat = .zero,
                 requireFooter: Bool = false,
                 footerWidth: CGFloat = .zero,
                 footerHeight: CGFloat = .zero,
-                enableScrolling: Bool = false) -> UICollectionViewCompositionalLayout {
+                enableScrolling: Bool = false,
+                sectionHandler: (([NSCollectionLayoutVisibleItem], CGPoint, NSCollectionLayoutEnvironment) -> Void)? = nil ) -> UICollectionViewCompositionalLayout {
         
         UICollectionViewCompositionalLayout { section, _ in
             self.section(
                 widthFraction: widthFraction,
                 heightFraction: heightFraction,
                 spacing: spacing,
+                groupWidthFraction: groupWidthFraction,
                 requireHeader: requireHeader,
                 headerWidth: headerWidth,
                 headerHeight: headerHeight,
                 requireFooter: requireFooter,
                 footerWidth: footerWidth,
                 footerHeight: footerHeight,
-                enableScrolling: enableScrolling
+                enableScrolling: enableScrolling,
+                sectionHandler: sectionHandler
             )
         }
     }
@@ -58,13 +62,15 @@ private extension CompositionalLayoutFactory {
     func section(widthFraction: CGFloat,
                  heightFraction: CGFloat,
                  spacing: Spacing,
+                 groupWidthFraction: CGFloat,
                  requireHeader: Bool,
                  headerWidth: CGFloat,
                  headerHeight: CGFloat,
                  requireFooter: Bool,
                  footerWidth: CGFloat,
                  footerHeight: CGFloat,
-                 enableScrolling: Bool) -> NSCollectionLayoutSection {
+                 enableScrolling: Bool,
+                 sectionHandler: (([NSCollectionLayoutVisibleItem], CGPoint, NSCollectionLayoutEnvironment) -> Void)?) -> NSCollectionLayoutSection {
         
         let widthFraction = widthFraction
         let heightFraction = heightFraction
@@ -82,16 +88,16 @@ private extension CompositionalLayoutFactory {
         )
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1),
+            widthDimension: .fractionalWidth(groupWidthFraction),
             heightDimension: .fractionalHeight(heightFraction)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
         section.boundarySupplementaryItems = []
-        
+
         if(enableScrolling) {
-            section.orthogonalScrollingBehavior = .groupPaging
+            section.orthogonalScrollingBehavior = .groupPagingCentered
         }
         
         if(requireHeader) {
@@ -123,7 +129,11 @@ private extension CompositionalLayoutFactory {
             
             section.boundarySupplementaryItems.append(footerItem)
         }
-        
+
+        if let sectionHandler = sectionHandler {
+            section.visibleItemsInvalidationHandler = sectionHandler
+        }
+
         return section
     }
 }


### PR DESCRIPTION
close #34 

- AlbumCollectionView의 NSCollectionLayoutSection에 `visibleItemInvalidateionHanlder` 클로저를 추가하여, 포커싱된 Cell 외의 Cell들은 모두 크기가 작고, 포커싱될 때 Cell의 크기가 커지는 효과를 추가

| 효과가 추가된 AlbumCollectionView|
| ------------------------------------------------------------ |
| ![SS2022-08-31PM05.09.07](https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202208311710011.gif)|