### PR TITLE
ColorPicker 도메인 관련 수정

### DIFF
--- a/rabit/rabit/Album/AlbumCoordinator.swift
+++ b/rabit/rabit/Album/AlbumCoordinator.swift
@@ -4,6 +4,8 @@ import RxRelay
 
 protocol AlbumNavigation {
     var showPhotoEditView: PublishRelay<Album.Item> { get }
+    var closeColorPickerView: PublishRelay<Void> { get }
+    var closePhotoEditView: PublishRelay<Void> { get }
 }
 
 protocol PhotoEditNavigation {
@@ -49,8 +51,10 @@ final class AlbumCoordinator: Coordinator, PhotoEditNavigation, AlbumNavigation,
 // MARK: - Navigation methods
 private extension AlbumCoordinator {
     func presentPhotoEditView(_ selectedPhoto: Album.Item) {
+        let repository = AlbumRepository()
         let viewModel = PhotoEditViewModel(
             selectedData: selectedPhoto,
+            repository: repository,
             navigation: self
         )
         let viewController = PhotoEdtiViewController(viewModel: viewModel)

--- a/rabit/rabit/Album/AlbumCoordinator.swift
+++ b/rabit/rabit/Album/AlbumCoordinator.swift
@@ -7,7 +7,7 @@ protocol AlbumNavigation {
 }
 
 protocol PhotoEditNavigation {
-    var showColorPickerView: PublishRelay<Void> { get }
+    var showColorPickerView: PublishRelay<BehaviorRelay<String>> { get }
     var showStylePickerView: PublishRelay<Void> { get }
     var closePhotoEditView: PublishRelay<Void> { get }
 }
@@ -23,7 +23,7 @@ final class AlbumCoordinator: Coordinator, PhotoEditNavigation, AlbumNavigation,
     var navigationController: UINavigationController
 
     let showPhotoEditView = PublishRelay<Album.Item>()
-    let showColorPickerView = PublishRelay<Void>()
+    let showColorPickerView = PublishRelay<BehaviorRelay<String>>()
     let showStylePickerView = PublishRelay<Void>()
     let closePhotoEditView = PublishRelay<Void>()
     let closeColorPickerView = PublishRelay<Void>()
@@ -64,14 +64,13 @@ private extension AlbumCoordinator {
         navigationController.presentedViewController?.dismiss(animated: true)
     }
 
-    func pushColorPickerView() {
-        guard let navigationController = self.navigationController.presentedViewController as? UINavigationController,
-              let photoEditViewController = navigationController.viewControllers.first as? PhotoEdtiViewController else {
+    func pushColorPickerView(colorStream: BehaviorRelay<String>) {
+        guard let navigationController = self.navigationController.presentedViewController as? UINavigationController else {
                   return
               }
 
         let viewModel = ColorPickerViewModel(
-            colorStream: photoEditViewController.hexPhotoColor,
+            colorStream: colorStream,
             navigation: self
         )
         let viewController = ColorPickerViewController(viewModel: viewModel)
@@ -104,7 +103,7 @@ private extension AlbumCoordinator {
             .disposed(by: disposeBag)
 
         showColorPickerView
-            .bind(onNext: pushColorPickerView)
+            .bind(onNext: pushColorPickerView(colorStream:))
             .disposed(by: disposeBag)
 
         showStylePickerView

--- a/rabit/rabit/Album/AlbumViewModel.swift
+++ b/rabit/rabit/Album/AlbumViewModel.swift
@@ -8,7 +8,7 @@ protocol AlbumViewModelInput {
 }
 
 protocol AlbumViewModelOutput {
-    var albumData: BehaviorSubject<[Album]> { get }
+    var albumData: BehaviorRelay<[Album]> { get }
 }
 
 protocol AlbumViewModelProtocol: AlbumViewModelInput, AlbumViewModelOutput { }
@@ -18,7 +18,7 @@ final class AlbumViewModel: AlbumViewModelProtocol {
 
     let requestAlbumData = PublishRelay<Void>()
     let photoSelected = PublishRelay<Album.Item>()
-    let albumData = BehaviorSubject<[Album]>(value: [])
+    let albumData = BehaviorRelay<[Album]>(value: [])
 
     private var disposeBag = DisposeBag()
 
@@ -45,6 +45,10 @@ private extension AlbumViewModel {
 
         photoSelected
             .bind(to: navigation.showPhotoEditView)
+            .disposed(by: disposeBag)
+
+        navigation.closeColorPickerView
+            .bind(to: requestAlbumData)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Album/AlbumViewModel.swift
+++ b/rabit/rabit/Album/AlbumViewModel.swift
@@ -47,7 +47,7 @@ private extension AlbumViewModel {
             .bind(to: navigation.showPhotoEditView)
             .disposed(by: disposeBag)
 
-        navigation.closeColorPickerView
+        navigation.closePhotoEditView
             .bind(to: requestAlbumData)
             .disposed(by: disposeBag)
     }

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
@@ -73,6 +73,22 @@ private extension ColorPickerViewController {
             }
             .disposed(by: disposeBag)
 
+        viewModel.selectedColor
+            .compactMap { (color) -> IndexPath? in
+                guard let index =  viewModel.presetColors
+                    .firstIndex(of: color) else { return nil }
+                return IndexPath(item: index, section: 0)
+            }
+            .withUnretained(self)
+            .bind(onNext: { viewController, indexPath in
+                viewController.presetColorCollectionView.selectItem(
+                    at: indexPath,
+                    animated: true,
+                    scrollPosition: .centeredVertically
+                )
+            })
+            .disposed(by: disposeBag)
+
         presetColorCollectionView.rx.modelSelected(String.self)
             .bind(to: viewModel.selectedColor)
             .disposed(by: disposeBag)

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
@@ -3,7 +3,7 @@ import RxSwift
 import RxRelay
 
 protocol ColorPickerViewModelInput {
-    var selectedColor: PublishSubject<String> { get }
+    var selectedColor: BehaviorRelay<String> { get }
     var backButtonTouched: PublishSubject<Void> { get }
 }
 
@@ -14,7 +14,7 @@ protocol ColorPickerViewModelOutput {
 protocol ColorPickerViewModelProtocol: ColorPickerViewModelInput, ColorPickerViewModelOutput { }
 
 final class ColorPickerViewModel: ColorPickerViewModelProtocol {
-    let selectedColor = PublishSubject<String>()
+    let selectedColor: BehaviorRelay<String>
     let backButtonTouched = PublishSubject<Void>()
     let presetColors = [
         "#E4B6BC", "#E09681", "#000000",
@@ -28,16 +28,17 @@ final class ColorPickerViewModel: ColorPickerViewModelProtocol {
     private var disposeBag = DisposeBag()
 
     init(
-        colorStream: PublishSubject<String>,
+        colorStream: BehaviorRelay<String>,
         navigation: ColorPickerNavigation
     ) {
+        selectedColor = .init(value: colorStream.value)
         bind(to: colorStream)
         bind(to: navigation)
     }
 }
 
 private extension ColorPickerViewModel {
-    func bind(to colorStream: PublishSubject<String>) {
+    func bind(to colorStream: BehaviorRelay<String>) {
         selectedColor
             .bind(to: colorStream)
             .disposed(by: disposeBag)

--- a/rabit/rabit/Album/Models/Photo.swift
+++ b/rabit/rabit/Album/Models/Photo.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct Photo {
+    let uuid: UUID
     let categoryTitle: String
     let goalTitle: String
     let imageData: Data
@@ -8,12 +9,14 @@ struct Photo {
     var color: String
 
     init(
+        uuid: UUID = UUID(),
         categoryTitle: String,
         goalTitle: String,
         imageData: Data,
         date: Date,
         color: String
     ) {
+        self.uuid = uuid
         self.categoryTitle = categoryTitle
         self.goalTitle = goalTitle
         self.imageData = imageData
@@ -25,6 +28,7 @@ struct Photo {
 extension Photo: Persistable {
     init(entity: PhotoEntity) {
         self.init(
+            uuid: entity.uuid,
             categoryTitle: entity.categoryTitle,
             goalTitle: entity.goalTitle,
             imageData: entity.imageData,
@@ -35,6 +39,7 @@ extension Photo: Persistable {
     
     func toEntity<T: PhotoEntity>() -> T {
         return T(
+            uuid: self.uuid,
             categoryTitle: self.categoryTitle,
             goalTitle: self.goalTitle,
             imageData: self.imageData,

--- a/rabit/rabit/Album/Models/PhotoEntity.swift
+++ b/rabit/rabit/Album/Models/PhotoEntity.swift
@@ -2,6 +2,7 @@ import Foundation
 import RealmSwift
 
 final class PhotoEntity: Object {
+    @Persisted var uuid: UUID = UUID()
     @Persisted var categoryTitle: String = ""
     @Persisted var goalTitle: String = ""
     @Persisted var imageData: Data = Data()
@@ -9,6 +10,7 @@ final class PhotoEntity: Object {
     @Persisted var color: String = ""
 
     convenience init(
+        uuid: UUID = UUID(),
         categoryTitle: String,
         goalTitle: String,
         imageData: Data,
@@ -16,10 +18,15 @@ final class PhotoEntity: Object {
         color: String
     ) {
         self.init()
+        self.uuid = uuid
         self.categoryTitle = categoryTitle
         self.goalTitle = goalTitle
         self.imageData = imageData
         self.date = date
         self.color = color
+    }
+
+    override static func primaryKey() -> String? {
+        return "uuid"
     }
 }

--- a/rabit/rabit/Album/Models/PhotoEntity.swift
+++ b/rabit/rabit/Album/Models/PhotoEntity.swift
@@ -10,7 +10,7 @@ final class PhotoEntity: Object {
     @Persisted var color: String = ""
 
     convenience init(
-        uuid: UUID = UUID(),
+        uuid: UUID,
         categoryTitle: String,
         goalTitle: String,
         imageData: Data,

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -31,7 +31,9 @@ final class PhotoEdtiViewController: UIViewController {
 
     private var viewModel: PhotoEditViewModelProtocol?
 
-    let hexPhotoColor = PublishSubject<String>()
+    var hexPhotoColor: BehaviorRelay<String> {
+        return .init(value: viewModel?.hexPhotoColor.value ?? "")
+    }
 
     private var disposeBag = DisposeBag()
 

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -31,10 +31,6 @@ final class PhotoEdtiViewController: UIViewController {
 
     private var viewModel: PhotoEditViewModelProtocol?
 
-    var hexPhotoColor: BehaviorRelay<String> {
-        return .init(value: viewModel?.hexPhotoColor.value ?? "")
-    }
-
     private var disposeBag = DisposeBag()
 
     convenience init(viewModel: PhotoEditViewModelProtocol) {
@@ -119,10 +115,6 @@ private extension PhotoEdtiViewController {
 
         navigationItem.leftBarButtonItem?.rx.tap
             .bind(to: viewModel.backButtonTouched)
-            .disposed(by: disposeBag)
-
-        hexPhotoColor
-            .bind(to: viewModel.hexPhotoColor)
             .disposed(by: disposeBag)
     }
 

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
@@ -72,5 +72,19 @@ private extension PhotoEditViewModel {
             }
             .bind(to: selectedPhotoData)
             .disposed(by: disposeBag)
+
+        hexPhotoColor
+            .withLatestFrom(selectedPhotoData) {
+                Album.Item(
+                    uuid: $1.uuid,
+                    categoryTitle: $1.categoryTitle,
+                    goalTitle: $1.goalTitle,
+                    imageData: $1.imageData,
+                    date: $1.date,
+                    color: $0
+                )
+            }
+            .bind(to: selectedPhotoData)
+            .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
@@ -44,6 +44,10 @@ final class PhotoEditViewModel: PhotoEditViewModelProtocol {
 private extension PhotoEditViewModel {
     func bind(to navigation: PhotoEditNavigation) {
         colorPickerButtonTouched
+            .withUnretained(self)
+            .map { viewModel, _ in
+                viewModel.hexPhotoColor
+            }
             .bind(to: navigation.showColorPickerView)
             .disposed(by: disposeBag)
 

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
@@ -68,21 +68,6 @@ private extension PhotoEditViewModel {
             })
             .disposed(by: disposeBag)
 
-        hexPhotoColor.withLatestFrom(selectedPhotoData)
-            .withUnretained(self)
-            .map { viewModel, photoData in
-                Album.Item(
-                    uuid: photoData.uuid,
-                    categoryTitle: photoData.categoryTitle,
-                    goalTitle: photoData.goalTitle,
-                    imageData: photoData.imageData,
-                    date: photoData.date,
-                    color: viewModel.hexPhotoColor.value
-                )
-            }
-            .bind(to: selectedPhotoData)
-            .disposed(by: disposeBag)
-
         hexPhotoColor
             .withLatestFrom(selectedPhotoData) {
                 Album.Item(

--- a/rabit/rabit/Album/Repository/AlbumRepository.swift
+++ b/rabit/rabit/Album/Repository/AlbumRepository.swift
@@ -3,6 +3,7 @@ import RxSwift
 
 protocol AlbumRepositoryProtocol {
     func fetchAlbumData() -> Observable<[Album]>
+    func updateAlbumData(_ data: Photo) -> Single<Bool>
 }
 
 final class AlbumRepository: AlbumRepositoryProtocol {
@@ -35,6 +36,22 @@ final class AlbumRepository: AlbumRepositoryProtocol {
             }
 
             observer.onNext(albumData)
+
+            return Disposables.create()
+        }
+    }
+
+    func updateAlbumData(_ data: Photo) -> Single<Bool> {
+
+        var result = true
+        do {
+            try realmManager.update(entity: data.toEntity())
+        } catch {
+            result = false
+        }
+
+        return .create { single in
+            single(.success(result))
 
             return Disposables.create()
         }

--- a/rabit/rabit/Album/Repository/AlbumRepository.swift
+++ b/rabit/rabit/Album/Repository/AlbumRepository.swift
@@ -6,20 +6,23 @@ protocol AlbumRepositoryProtocol {
 }
 
 final class AlbumRepository: AlbumRepositoryProtocol {
+
+    private let realmManager = RealmManager.shared
+
     func fetchAlbumData() -> Observable<[Album]> {
 
-        return Observable.create { observer in
+        return Observable.create { [weak self] observer in
 
-            let realmManager = RealmManager.shared
+            guard let self = self else { return Disposables.create() }
 
-            let fetchedGoalDetailData = realmManager.read(entity: CategoryEntity.self)
+            let fetchedGoalDetailData = self.realmManager.read(entity: CategoryEntity.self)
 
             var albumData = [Album]()
 
             fetchedGoalDetailData.forEach {
                 let categoryTitle = $0.title
 
-                let fetchedPhotoData = realmManager
+                let fetchedPhotoData = self.realmManager
                     .read(
                         entity: PhotoEntity.self,
                         filter: "categoryTitle == '\(categoryTitle)'"

--- a/rabit/rabit/Album/Repository/AlbumRepository.swift
+++ b/rabit/rabit/Album/Repository/AlbumRepository.swift
@@ -2,7 +2,7 @@ import Foundation
 import RxSwift
 
 protocol AlbumRepositoryProtocol {
-    func fetchAlbumData() -> Observable<[Album]>
+    func fetchAlbumData() -> Single<[Album]>
     func updateAlbumData(_ data: Photo) -> Single<Bool>
 }
 
@@ -10,32 +10,11 @@ final class AlbumRepository: AlbumRepositoryProtocol {
 
     private let realmManager = RealmManager.shared
 
-    func fetchAlbumData() -> Observable<[Album]> {
+    func fetchAlbumData() -> Single<[Album]> {
+        let fetchedAlbumData = getLatestAlbum()
 
-        return Observable.create { [weak self] observer in
-
-            guard let self = self else { return Disposables.create() }
-
-            let fetchedGoalDetailData = self.realmManager.read(entity: CategoryEntity.self)
-
-            var albumData = [Album]()
-
-            fetchedGoalDetailData.forEach {
-                let categoryTitle = $0.title
-
-                let fetchedPhotoData = self.realmManager
-                    .read(
-                        entity: PhotoEntity.self,
-                        filter: "categoryTitle == '\(categoryTitle)'"
-                    )
-                    .map { Photo(entity: $0) }
-
-                if !fetchedPhotoData.isEmpty {
-                    albumData.append(Album(categoryTitle: categoryTitle, items: fetchedPhotoData))
-                }
-            }
-
-            observer.onNext(albumData)
+        return .create { single in
+            single(.success(fetchedAlbumData))
 
             return Disposables.create()
         }
@@ -55,5 +34,29 @@ final class AlbumRepository: AlbumRepositoryProtocol {
 
             return Disposables.create()
         }
+    }
+}
+
+private extension AlbumRepository {
+    func getLatestAlbum() -> [Album] {
+        let fetchedCategoryData = realmManager.read(entity: CategoryEntity.self)
+
+        var albumData = [Album]()
+
+        fetchedCategoryData.forEach {
+            let categoryTitle = $0.title
+
+            let fetchedPhotoData = realmManager.read(entity: PhotoEntity.self, filter: "categoryTitle == '\(categoryTitle)'")
+                .map(Photo.init)
+
+            if !fetchedPhotoData.isEmpty {
+                albumData.append(Album(
+                    categoryTitle: categoryTitle,
+                    items: fetchedPhotoData
+                ))
+            }
+        }
+
+        return albumData
     }
 }

--- a/rabit/rabit/Common/RealmManager.swift
+++ b/rabit/rabit/Common/RealmManager.swift
@@ -23,4 +23,10 @@ final class RealmManager {
             realm.add(entity)
         }
     }
+
+    func update<T: Object>(entity: T) throws {
+        try? realm.write {
+            realm.add(entity, update: .modified)
+        }
+    }
 }


### PR DESCRIPTION
close #42 

## 진행 사항
1. ColorPickerView의 CollectionView Cell 중, 선택된 Photo 데이터의 color 프로퍼티와 같은 값을 가지는 Cell이 선택되어 있도록 함.
2. 토론한 내용처럼, Coordinator의 Observable 프로퍼티의 value Type을 수정하여 ViewModel 간 데이터 전송 로직 구현 -> PhotoEditVC에 있던 Observable 프로퍼티 제거
3. Realm의 `update` 로직 구현 (KeyType이 반드시 필요한 update 로직) -> PhotoEditVC에서 AlbumVC로 갈 때에 Realm 업데이트하도록 흐름 수정
4. PhotoEditVC에서 AlbumVC로 돌아왔음을 AlbumVC가 알 수 있도록 `AlbumNavigation` 프로토콜에 프로퍼티 추가
