### PR TITLE
RangeSlider 구현, 뷰모델 간 데이터 전달방식 수정

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		B569EA132898D4AB006FFFB9 /* rabitUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569EA122898D4AB006FFFB9 /* rabitUITests.swift */; };
 		B569EA152898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569EA142898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift */; };
 		B56AF75028C59E18001C82C0 /* RangeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56AF74F28C59E18001C82C0 /* RangeSlider.swift */; };
+		B56AF75228C6528B001C82C0 /* RangeSlider + Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56AF75128C6528B001C82C0 /* RangeSlider + Reactive.swift */; };
 		B57D75F428B3E76300C11405 /* UIView + shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D75F328B3E76300C11405 /* UIView + shadow.swift */; };
 		B57D75F928B5319D00C11405 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = B57D75F828B5319D00C11405 /* RxGesture */; };
 		B582573C28BDF6F2001AE268 /* DateComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B582573B28BDF6F2001AE268 /* DateComponent.swift */; };
@@ -134,6 +135,7 @@
 		B569EA122898D4AB006FFFB9 /* rabitUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rabitUITests.swift; sourceTree = "<group>"; };
 		B569EA142898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rabitUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		B56AF74F28C59E18001C82C0 /* RangeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSlider.swift; sourceTree = "<group>"; };
+		B56AF75128C6528B001C82C0 /* RangeSlider + Reactive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeSlider + Reactive.swift"; sourceTree = "<group>"; };
 		B57D75F328B3E76300C11405 /* UIView + shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView + shadow.swift"; sourceTree = "<group>"; };
 		B582573B28BDF6F2001AE268 /* DateComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateComponent.swift; sourceTree = "<group>"; };
 		B582573D28BDF718001AE268 /* Date + toDateComponent, toTimeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date + toDateComponent, toTimeComponent.swift"; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				02B916DA28B89ADF0086F29E /* RealmResults + toArray.swift */,
 				B57D75F328B3E76300C11405 /* UIView + shadow.swift */,
 				B582573D28BDF718001AE268 /* Date + toDateComponent, toTimeComponent.swift */,
+				B56AF75128C6528B001C82C0 /* RangeSlider + Reactive.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				B5D131D2289A087000EE1833 /* MainCoordinator.swift in Sources */,
 				B5D7603128A37D630046B09C /* GoalListCollectionViewHeader.swift in Sources */,
 				B5B9413C28AF6DE60098022F /* GoalAddViewController.swift in Sources */,
+				B56AF75228C6528B001C82C0 /* RangeSlider + Reactive.swift in Sources */,
 				B563D9BE28BA5A3C00A755EB /* Period.swift in Sources */,
 				B58A1C2328B5F9AF00D5783F /* RealmManager.swift in Sources */,
 				B563D9C028BA5A8F00A755EB /* PeriodSelectViewController.swift in Sources */,

--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		B569EA092898D4AB006FFFB9 /* rabitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569EA082898D4AB006FFFB9 /* rabitTests.swift */; };
 		B569EA132898D4AB006FFFB9 /* rabitUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569EA122898D4AB006FFFB9 /* rabitUITests.swift */; };
 		B569EA152898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569EA142898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift */; };
+		B56AF75028C59E18001C82C0 /* RangeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56AF74F28C59E18001C82C0 /* RangeSlider.swift */; };
 		B57D75F428B3E76300C11405 /* UIView + shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D75F328B3E76300C11405 /* UIView + shadow.swift */; };
 		B57D75F928B5319D00C11405 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = B57D75F828B5319D00C11405 /* RxGesture */; };
 		B582573C28BDF6F2001AE268 /* DateComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B582573B28BDF6F2001AE268 /* DateComponent.swift */; };
@@ -132,6 +133,7 @@
 		B569EA0E2898D4AB006FFFB9 /* rabitUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = rabitUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B569EA122898D4AB006FFFB9 /* rabitUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rabitUITests.swift; sourceTree = "<group>"; };
 		B569EA142898D4AB006FFFB9 /* rabitUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = rabitUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B56AF74F28C59E18001C82C0 /* RangeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSlider.swift; sourceTree = "<group>"; };
 		B57D75F328B3E76300C11405 /* UIView + shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView + shadow.swift"; sourceTree = "<group>"; };
 		B582573B28BDF6F2001AE268 /* DateComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateComponent.swift; sourceTree = "<group>"; };
 		B582573D28BDF718001AE268 /* Date + toDateComponent, toTimeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date + toDateComponent, toTimeComponent.swift"; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 			isa = PBXGroup;
 			children = (
 				B58EF87628B8BABC0075B295 /* BottomSheet.swift */,
+				B56AF74F28C59E18001C82C0 /* RangeSlider.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				0232BD9528AE11DD009057F8 /* ColorPickerViewModel.swift in Sources */,
 				02F37254289E1EA200F361C7 /* PaddingLabel.swift in Sources */,
 				B5D131E8289C2D1100EE1833 /* Category.swift in Sources */,
+				B56AF75028C59E18001C82C0 /* RangeSlider.swift in Sources */,
 				02972D5F28B74343008C097D /* PhotoEntity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -21,10 +21,11 @@ final class RangeSlider: UIControl {
         return button
     }()
     
-    private let trackView: UIView = {
+    private lazy var trackView: UIView = {
         let view = UIView()
-        view.backgroundColor = .gray
+        view.backgroundColor = .lightGray
         view.isUserInteractionEnabled = false
+        view.roundCorners(5)
         return view
     }()
     
@@ -58,6 +59,18 @@ final class RangeSlider: UIControl {
     
     lazy var rightValue: Double = maxValue {
         didSet { self.updateLayout(to: rightValue, direction: .right) }
+    }
+    
+    var trackViewColor: UIColor = .lightGray {
+        didSet {
+            trackView.backgroundColor = trackViewColor
+        }
+    }
+    
+    var trackTintViewColor: UIColor = .systemBlue {
+        didSet {
+            trackTintView.backgroundColor = trackTintViewColor
+        }
     }
     
     convenience init(min: Double, max: Double) {
@@ -100,7 +113,7 @@ final class RangeSlider: UIControl {
         
         trackView.snp.makeConstraints {
             $0.left.right.centerY.equalToSuperview()
-            $0.height.equalToSuperview().multipliedBy(0.2)
+            $0.height.equalToSuperview().multipliedBy(0.4)
         }
         
         trackTintView.snp.makeConstraints {

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -52,25 +52,27 @@ final class RangeSlider: UIControl {
         didSet { self.rightValue = maxValue }
     }
     
-    var leftValue: Double = 0.0 {
+    lazy var leftValue: Double = minValue {
         didSet { self.updateLayout(to: leftValue, direction: .left) }
     }
     
-    var rightValue: Double = 100.0 {
+    lazy var rightValue: Double = maxValue {
         didSet { self.updateLayout(to: rightValue, direction: .right) }
     }
     
-    convenience init(
-        min: Double, max: Double, left: Double, right: Double
-    ) {
+    convenience init(min: Double, max: Double) {
         self.init()
         
         self.minValue = min
         self.maxValue = max
-        self.leftValue = left
-        self.rightValue = right
         
         setupViews()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateLayout(to: rightValue, direction: .right)
+        updateLayout(to: leftValue, direction: .left)
     }
     
     private func setupViews() {

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -138,11 +138,8 @@ final class RangeSlider: UIControl {
         isRightThumbTouched = rightThumbButton.frame.contains(touchedPoint)
         previousTouchedPoint = touchedPoint
         
-        if isLeftThumbTouched {
-            leftThumbButton.isSelected = true
-        } else {
-            rightThumbButton.isSelected = true
-        }
+        leftThumbButton.isSelected = isLeftThumbTouched
+        rightThumbButton.isSelected = isRightThumbTouched
         
         return isLeftThumbTouched || isRightThumbTouched
     }

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -1,0 +1,205 @@
+import UIKit
+import SnapKit
+
+private extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        min(max(self, limits.lowerBound), limits.upperBound)
+    }
+}
+
+final class RangeSlider: UIControl {
+    
+    private let leftThumbButton: ThumbButton = {
+        let button = ThumbButton()
+        button.isUserInteractionEnabled = false
+        return button
+    }()
+    
+    private let rightThumbButton: ThumbButton = {
+        let button = ThumbButton()
+        button.isUserInteractionEnabled = false
+        return button
+    }()
+    
+    private let trackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+    
+    private let trackTintView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBlue
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+    
+    private var previousTouchedPoint: CGPoint = .zero
+    private var isLeftThumbTouched: Bool = false
+    private var isRightThumbTouched: Bool = false
+    private var leftConstraint: Constraint?
+    private var rightConstraint: Constraint?
+    private var widthWithoutThumb: Double {
+        return self.bounds.width - Double(bounds.height)
+    }
+    
+    private var minValue: Double = 0.0 {
+        didSet { self.leftValue = minValue }
+    }
+    
+    private var maxValue: Double = 100.0 {
+        didSet { self.rightValue = maxValue }
+    }
+    
+    var leftValue: Double = 0.0 {
+        didSet { self.updateLayout(to: leftValue, direction: .left) }
+    }
+    
+    var rightValue: Double = 100.0 {
+        didSet { self.updateLayout(to: rightValue, direction: .right) }
+    }
+    
+    convenience init(
+        min: Double, max: Double, left: Double, right: Double
+    ) {
+        self.init()
+        
+        self.minValue = min
+        self.maxValue = max
+        self.leftValue = left
+        self.rightValue = right
+        
+        setupViews()
+    }
+    
+    private func setupViews() {
+        
+        addSubview(trackView)
+        addSubview(trackTintView)
+        addSubview(leftThumbButton)
+        addSubview(rightThumbButton)
+        
+        leftThumbButton.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.right.lessThanOrEqualTo(rightThumbButton.snp.left)
+            $0.left.greaterThanOrEqualToSuperview()
+            $0.width.equalTo(self.snp.height)
+            self.leftConstraint = $0.left.equalTo(self.snp.left).priority(999).constraint
+        }
+        
+        rightThumbButton.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.left.greaterThanOrEqualTo(leftThumbButton.snp.right)
+            $0.right.lessThanOrEqualToSuperview()
+            $0.width.equalTo(self.snp.height)
+            self.rightConstraint = $0.left.equalTo(self.snp.left).priority(999).constraint
+        }
+        
+        trackView.snp.makeConstraints {
+            $0.left.right.centerY.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(0.2)
+        }
+        
+        trackTintView.snp.makeConstraints {
+            $0.left.equalTo(leftThumbButton.snp.right)
+            $0.right.equalTo(rightThumbButton.snp.left)
+            $0.top.bottom.equalTo(trackView)
+        }
+    }
+    
+    //슬라이더 전체가 아닌 ThumbButton 범위에서만 터치 이벤트 받도록 설정
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        super.point(inside: point, with: event)
+        return leftThumbButton.frame.contains(point) || rightThumbButton.frame.contains(point)
+    }
+    
+    //터치 시작 시에, 리턴값에 따라 터치 이벤트 처리를 계속 할 지 결정
+    override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        super.beginTracking(touch, with: event)
+        
+        let touchedPoint = touch.location(in: self)
+        isLeftThumbTouched = leftThumbButton.frame.contains(touchedPoint)
+        isRightThumbTouched = rightThumbButton.frame.contains(touchedPoint)
+        previousTouchedPoint = touchedPoint
+        
+        if isLeftThumbTouched {
+            leftThumbButton.isSelected = true
+        } else {
+            rightThumbButton.isSelected = true
+        }
+        
+        return isLeftThumbTouched || isRightThumbTouched
+    }
+    
+    //beginTracking에서 true리턴 후, 터치 이벤트를 지속하기 위한 메소드(드래그 구현 시 사용)
+    override func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+        super.continueTracking(touch, with: event)
+        
+        let touchedPoint = touch.location(in: self)
+        let draggedValue = Double(touchedPoint.x - previousTouchedPoint.x)
+        let scale = maxValue - minValue
+        let scaledValue = scale * draggedValue / widthWithoutThumb
+        
+        if isLeftThumbTouched {
+            leftValue = (leftValue + scaledValue).clamped(to: minValue...rightValue)
+        } else {
+            rightValue = (rightValue + scaledValue).clamped(to: leftValue...maxValue)
+        }
+        
+        previousTouchedPoint = touchedPoint
+        sendActions(for: .valueChanged)
+
+        return true
+    }
+    
+    //터치가 끝난 시점(화면에서 손가락을 뗀 시점)에 버튼의 isSelected를 모두 false로 처리
+    override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+        super.endTracking(touch, with: event)
+        sendActions(for: .valueChanged)
+        
+        leftThumbButton.isSelected = false
+        rightThumbButton.isSelected = false
+    }
+    
+    //업데이트 된 rangleValue에 맞춰 터치된 버튼의 left 레이아웃 속성을 업데이트
+    private func updateLayout(to rangeValue: CGFloat, direction: SlidingDirection) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            let startValue = rangeValue - self.minValue
+            let scale = self.maxValue - self.minValue
+            let offset = self.widthWithoutThumb * startValue / scale
+            
+            switch direction {
+            case .left:
+                self.leftConstraint?.update(offset: offset)
+            case .right:
+                self.rightConstraint?.update(offset: offset)
+            }
+        }
+    }
+}
+
+private extension RangeSlider {
+    
+    enum SlidingDirection {
+        case left
+        case right
+    }
+    
+    final class ThumbButton: UIButton {
+        
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            setAttributes()
+        }
+        
+        private func setAttributes() {
+            roundCorners(frame.height/2)
+            backgroundColor = .white
+            layer.borderWidth = 1.0
+            layer.borderColor = UIColor.gray.cgColor
+        }
+    }
+}

--- a/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
+++ b/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
@@ -12,7 +12,6 @@ protocol GoalAddViewModelInput {
 
 protocol GoalAddViewModelOutput {
     
-    var periodSelectViewModel: PublishRelay<PeriodSelectViewModel> { get }
     var timeSelectViewModel: PublishRelay<TimeSelectViewModel> { get }
     var selectedPeriod: PublishRelay<Period> { get }
     var selectedTime: PublishRelay<CertifiableTime> { get }
@@ -24,7 +23,6 @@ final class GoalAddViewModel: GoalAddViewModelInput, GoalAddViewModelOutput {
     let closeButtonTouched = PublishRelay<Void>()
     let periodFieldTouched = PublishRelay<Void>()
     let timeFieldTouched = PublishRelay<Void>()
-    let periodSelectViewModel = PublishRelay<PeriodSelectViewModel>()
     let selectedPeriod = PublishRelay<Period>()
     let timeSelectViewModel = PublishRelay<TimeSelectViewModel>()
     let selectedTime = PublishRelay<CertifiableTime>()
@@ -49,18 +47,11 @@ private extension GoalAddViewModel {
             .disposed(by: disposeBag)
         
         periodFieldTouched
-            .map { PeriodSelectViewModel(navigation: navigation) }
-            .bind(to: periodSelectViewModel)
-            .disposed(by: disposeBag)
-        
-        periodSelectViewModel
-            .map { $0 }
-            .bind(to: navigation.showPeriodSelectView)
-            .disposed(by: disposeBag)
-        
-        periodSelectViewModel
-            .flatMapLatest { $0.selectedPeriod }
-            .bind(to: selectedPeriod)
+            .withUnretained(self)
+            .map { viewModel, _ in
+                viewModel.selectedPeriod
+            }
+            .bind(onNext: navigation.showPeriodSelectView)
             .disposed(by: disposeBag)
         
         timeFieldTouched

--- a/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
+++ b/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
@@ -12,7 +12,6 @@ protocol GoalAddViewModelInput {
 
 protocol GoalAddViewModelOutput {
     
-    var timeSelectViewModel: PublishRelay<TimeSelectViewModel> { get }
     var selectedPeriod: PublishRelay<Period> { get }
     var selectedTime: PublishRelay<CertifiableTime> { get }
 }
@@ -24,7 +23,6 @@ final class GoalAddViewModel: GoalAddViewModelInput, GoalAddViewModelOutput {
     let periodFieldTouched = PublishRelay<Void>()
     let timeFieldTouched = PublishRelay<Void>()
     let selectedPeriod = PublishRelay<Period>()
-    let timeSelectViewModel = PublishRelay<TimeSelectViewModel>()
     let selectedTime = PublishRelay<CertifiableTime>()
     
     private let disposeBag = DisposeBag()
@@ -55,17 +53,9 @@ private extension GoalAddViewModel {
             .disposed(by: disposeBag)
         
         timeFieldTouched
-            .map { TimeSelectViewModel(navigation: navigation) }
-            .bind(to: timeSelectViewModel)
-            .disposed(by: disposeBag)
-        
-        timeSelectViewModel
-            .bind(to: navigation.showTimeSelectView)
-            .disposed(by: disposeBag)
-        
-        timeSelectViewModel
-            .flatMapLatest { $0.selectedTime }
-            .bind(to: selectedTime)
+            .withUnretained(self)
+            .map { viewModel, _ in viewModel.selectedTime }
+            .bind(onNext: navigation.showTimeSelectView)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
+++ b/rabit/rabit/Goal/GoalAdd/GoalAddViewModel.swift
@@ -12,8 +12,8 @@ protocol GoalAddViewModelInput {
 
 protocol GoalAddViewModelOutput {
     
-    var selectedPeriod: PublishRelay<Period> { get }
-    var selectedTime: PublishRelay<CertifiableTime> { get }
+    var selectedPeriod: BehaviorRelay<Period> { get }
+    var selectedTime: BehaviorRelay<CertifiableTime> { get }
 }
 
 final class GoalAddViewModel: GoalAddViewModelInput, GoalAddViewModelOutput {
@@ -22,8 +22,8 @@ final class GoalAddViewModel: GoalAddViewModelInput, GoalAddViewModelOutput {
     let closeButtonTouched = PublishRelay<Void>()
     let periodFieldTouched = PublishRelay<Void>()
     let timeFieldTouched = PublishRelay<Void>()
-    let selectedPeriod = PublishRelay<Period>()
-    let selectedTime = PublishRelay<CertifiableTime>()
+    let selectedPeriod = BehaviorRelay<Period>(value: Period())
+    let selectedTime = BehaviorRelay<CertifiableTime>(value: CertifiableTime())
     
     private let disposeBag = DisposeBag()
     
@@ -46,16 +46,14 @@ private extension GoalAddViewModel {
         
         periodFieldTouched
             .withUnretained(self)
-            .map { viewModel, _ in
-                viewModel.selectedPeriod
-            }
-            .bind(onNext: navigation.showPeriodSelectView)
+            .map { $0.0.selectedPeriod }
+            .bind(to: navigation.showPeriodSelectView)
             .disposed(by: disposeBag)
         
         timeFieldTouched
             .withUnretained(self)
-            .map { viewModel, _ in viewModel.selectedTime }
-            .bind(onNext: navigation.showTimeSelectView)
+            .map { $0.0.selectedTime }
+            .bind(to: navigation.showTimeSelectView)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Goal/GoalCoordinator.swift
+++ b/rabit/rabit/Goal/GoalCoordinator.swift
@@ -8,7 +8,7 @@ protocol GoalNavigation {
     var closeCategoryAddView: PublishRelay<Void> { get }
     var showGoalAddView: PublishRelay<Void> { get }
     var closeGoalAddView: PublishRelay<Void> { get }
-    var showPeriodSelectView: PublishRelay<PeriodSelectViewModel> { get }
+    var showPeriodSelectView: (PublishRelay<Period>) -> Void { get }
     var closePeriodSelectView: PublishRelay<Void> { get }
     var showTimeSelectView: PublishRelay<TimeSelectViewModel> { get }
     var closeTimeSelectView: PublishRelay<Void> { get }
@@ -24,7 +24,9 @@ final class GoalCoordinator: Coordinator, GoalNavigation {
     let closeCategoryAddView = PublishRelay<Void>()
     let showGoalAddView = PublishRelay<Void>()
     let closeGoalAddView = PublishRelay<Void>()
-    let showPeriodSelectView = PublishRelay<PeriodSelectViewModel>()
+    private (set) lazy var showPeriodSelectView: (PublishRelay<Period>) -> Void = { periodStream in
+        self.presentPeriodSelectViewController(with: periodStream)
+    }
     let closePeriodSelectView = PublishRelay<Void>()
     let showTimeSelectView = PublishRelay<TimeSelectViewModel>()
     let closeTimeSelectView = PublishRelay<Void>()
@@ -60,10 +62,6 @@ final class GoalCoordinator: Coordinator, GoalNavigation {
             })
             .disposed(by: disposeBag)
         
-        showPeriodSelectView
-            .bind(onNext: presentPeriodSelectViewController)
-            .disposed(by: disposeBag)
-        
         closePeriodSelectView
             .withUnretained(self)
             .bind(onNext: { coordinator, _ in
@@ -88,14 +86,17 @@ final class GoalCoordinator: Coordinator, GoalNavigation {
         pushGoalListViewController()
         bind()
     }
+}
+
+private extension GoalCoordinator {
     
-    private func pushGoalListViewController() {
+    func pushGoalListViewController() {
         let viewModel = GoalListViewModel(navigation: self)
         let viewController = GoalListViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: true)
     }
     
-    private func presentCategoryAddViewController() {
+    func presentCategoryAddViewController() {
 
         let viewModel = CategoryAddViewModel(navigation: self)
         let viewController = CategoryAddViewController(viewModel: viewModel)
@@ -103,26 +104,27 @@ final class GoalCoordinator: Coordinator, GoalNavigation {
         navigationController.present(viewController, animated: false)
     }
     
-    private func dismissCurrentView(animated: Bool) {
+    func dismissCurrentView(animated: Bool) {
         
         navigationController.presentedViewController?.dismiss(animated: animated)
     }
     
-    private func presentGoalAddViewController() {
+    func presentGoalAddViewController() {
 
         let viewModel = GoalAddViewModel(navigation: self)
         let viewController = GoalAddViewController(viewModel: viewModel)
         navigationController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
     
-    private func presentPeriodSelectViewController(viewModel: PeriodSelectViewModel) {
+    func presentPeriodSelectViewController(with periodStream: PublishRelay<Period>) {
         
+        let viewModel = PeriodSelectViewModel(navigation: self, with: periodStream)
         let viewController = PeriodSelectViewController(viewModel: viewModel)
         viewController.modalPresentationStyle = .overCurrentContext
         navigationController.presentedViewController?.present(viewController, animated: false)
     }
     
-    private func presentTimeSelectViewController(viewModel: TimeSelectViewModel) {
+    func presentTimeSelectViewController(viewModel: TimeSelectViewModel) {
         
         let viewController = TimeSelectViewController(viewModel: viewModel)
         viewController.modalPresentationStyle = .overCurrentContext

--- a/rabit/rabit/Goal/GoalCoordinator.swift
+++ b/rabit/rabit/Goal/GoalCoordinator.swift
@@ -122,7 +122,7 @@ private extension GoalCoordinator {
         
         let viewModel = PeriodSelectViewModel(navigation: self, with: periodStream)
         let viewController = PeriodSelectViewController(viewModel: viewModel)
-        viewController.modalPresentationStyle = .overCurrentContext
+        viewController.modalPresentationStyle = .overFullScreen
         navigationController.presentedViewController?.present(viewController, animated: false)
     }
     
@@ -130,7 +130,7 @@ private extension GoalCoordinator {
         
         let viewModel = TimeSelectViewModel(navigation: self, with: timeStream)
         let viewController = TimeSelectViewController(viewModel: viewModel)
-        viewController.modalPresentationStyle = .overCurrentContext
+        viewController.modalPresentationStyle = .overFullScreen
         navigationController.presentedViewController?.present(viewController, animated: false)
     }
 }

--- a/rabit/rabit/Goal/Models/CertifiableTime.swift
+++ b/rabit/rabit/Goal/Models/CertifiableTime.swift
@@ -22,6 +22,12 @@ struct CertifiableTime: CustomStringConvertible {
         return "\(start.formattedString) ~ \(end.formattedString)"
     }
     
+    init() {
+        let currDate = Date()
+        self.start = currDate.toTimeComponent()
+        self.end = currDate.toTimeComponent()
+    }
+    
     init(start: Date, end: Date) {
         self.start = start.toTimeComponent()
         self.end = end.toTimeComponent()

--- a/rabit/rabit/Goal/Models/CertifiableTime.swift
+++ b/rabit/rabit/Goal/Models/CertifiableTime.swift
@@ -32,4 +32,9 @@ struct CertifiableTime: CustomStringConvertible {
         self.start = start.toTimeComponent()
         self.end = end.toTimeComponent()
     }
+    
+    init(start: Int, end: Int) {
+        self.start = TimeComponent(rawValue: start)
+        self.end = TimeComponent(rawValue: end)
+    }
 }

--- a/rabit/rabit/Goal/Models/Period.swift
+++ b/rabit/rabit/Goal/Models/Period.swift
@@ -8,6 +8,12 @@ struct Period: CustomStringConvertible {
     var description: String {
         return "\(start.formattedString) ~ \(end.formattedString)"
     }
+    
+    init() {
+        let currDate = Date()
+        self.start = currDate.toDateComponent()
+        self.end = currDate.toDateComponent()
+    }
         
     init(start: Date, end: Date) {
         self.start = start.toDateComponent()

--- a/rabit/rabit/Goal/Models/TimeComponent.swift
+++ b/rabit/rabit/Goal/Models/TimeComponent.swift
@@ -12,6 +12,18 @@ struct TimeComponent {
         let hour = isMorning ? hour : hour-12
         return "\(ampm) \(hour)시 \(minute)분"
     }
+    
+    init(hour: Int, minute: Int, seconds: Int) {
+        self.hour = hour
+        self.minute = minute
+        self.seconds = seconds
+    }
+    
+    init(rawValue seconds: Int) {
+        self.hour = seconds/3600
+        self.minute = (seconds % 3600) / 60
+        self.seconds = (seconds % 3600) % 60
+    }
 }
 
 extension TimeComponent {

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
@@ -21,8 +21,11 @@ final class PeriodSelectViewController: UIViewController {
     //추후 달력화면 구현시 수정해야 함
     private let calendarView: UIDatePicker = {
         let datePicker = UIDatePicker()
-        datePicker.locale = Locale(identifier: "ko-KR")
         datePicker.datePickerMode = .date
+        
+        if #available(iOS 14.0, *) {
+            datePicker.preferredDatePickerStyle = .inline
+        }
         return datePicker
     }()
     

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewModel.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewModel.swift
@@ -25,14 +25,14 @@ final class PeriodSelectViewModel: PeriodSelectViewModelInput, PeriodSelectViewM
     
     init(
         navigation: GoalNavigation,
-        with periodStream: PublishRelay<Period>
+        with periodStream: BehaviorRelay<Period>
     ) {
         bind(to: navigation, with: periodStream)
     }
     
     func bind(
         to navigation: GoalNavigation,
-        with periodStream: PublishRelay<Period>
+        with periodStream: BehaviorRelay<Period>
     ) {
         
         closingViewRequested

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewModel.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewModel.swift
@@ -12,7 +12,6 @@ protocol PeriodSelectViewModelOutput {
     
     var selectedStartDate: PublishRelay<Date> { get }
     var selectedEndDate: PublishRelay<Date> { get }
-    var selectedPeriod: PublishRelay<Period> { get }
 }
 
 final class PeriodSelectViewModel: PeriodSelectViewModelInput, PeriodSelectViewModelOutput {
@@ -21,15 +20,20 @@ final class PeriodSelectViewModel: PeriodSelectViewModelInput, PeriodSelectViewM
     let saveButtonTouched = PublishRelay<Void>()
     let selectedStartDate = PublishRelay<Date>()
     let selectedEndDate = PublishRelay<Date>()
-    let selectedPeriod = PublishRelay<Period>()
     
     private let disposeBag = DisposeBag()
     
-    init(navigation: GoalNavigation) {
-        bind(to: navigation)
+    init(
+        navigation: GoalNavigation,
+        with periodStream: PublishRelay<Period>
+    ) {
+        bind(to: navigation, with: periodStream)
     }
     
-    func bind(to navigation: GoalNavigation) {
+    func bind(
+        to navigation: GoalNavigation,
+        with periodStream: PublishRelay<Period>
+    ) {
         
         closingViewRequested
             .bind(to: navigation.closePeriodSelectView)
@@ -44,7 +48,7 @@ final class PeriodSelectViewModel: PeriodSelectViewModelInput, PeriodSelectViewM
         
         saveButtonTouched
             .withLatestFrom(period)
-            .bind(to: selectedPeriod)
+            .bind(to: periodStream)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -18,7 +18,7 @@ final class TimeSelectViewController: UIViewController {
         return sheet
     }()
     
-    private let timeRangleSlider: RangeSlider = {
+    private let timeRangeSlider: RangeSlider = {
         let slider = RangeSlider(min: 60, max: 60*60*23 + 60*59)
         return slider
     }()
@@ -80,14 +80,14 @@ final class TimeSelectViewController: UIViewController {
             }
             .disposed(by: disposeBag)
        
-        timeRangleSlider.rx.leftValue
+        timeRangeSlider.rx.leftValue
             .bind(to: viewModel.selectedStartTime)
             .disposed(by: disposeBag)
         
-        timeRangleSlider.rx.rightValue
+        timeRangeSlider.rx.rightValue
             .bind(to: viewModel.selectedEndTime)
             .disposed(by: disposeBag)
-
+        
         viewModel.selectedTime
             .map { $0.description }
             .bind(to: timePreviewLabel.rx.text)
@@ -115,18 +115,17 @@ final class TimeSelectViewController: UIViewController {
             $0.top.equalTo(view.snp.bottom)
         }
         
+        timeSelectSheet.contentView.addSubview(timeRangeSlider)
+        timeRangeSlider.snp.makeConstraints {
+            $0.height.equalToSuperview().multipliedBy(0.08)
+            $0.width.equalToSuperview().multipliedBy(0.9)
+            $0.centerX.centerY.equalToSuperview()
+        }
+        
         timeSelectSheet.contentView.addSubview(timePreviewLabel)
         timePreviewLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview()
-        }
-        
-        timeSelectSheet.contentView.addSubview(timeRangleSlider)
-        timeRangleSlider.snp.makeConstraints {
-            $0.height.equalTo(60)
-            $0.width.equalToSuperview().multipliedBy(0.7)
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview()
+            $0.bottom.equalTo(timeRangeSlider.snp.top).offset(-10)
         }
         
         timeSelectSheet.contentView.addSubview(saveButton)
@@ -145,7 +144,7 @@ private extension TimeSelectViewController {
         isModalInPresentation = true
         
         timeSelectSheet.move(
-            upTo: view.bounds.height*0.45,
+            upTo: view.bounds.height*0.55,
             duration: 0.2,
             animation: self.view.layoutIfNeeded
         )

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -75,7 +75,7 @@ final class TimeSelectViewController: UIViewController {
         timeSelectSheet.rx.swipeGesture(.down)
             .when(.ended)
             .withUnretained(self)
-            .bind { viewController, temp in
+            .bind { viewController, _ in
                 viewController.hidePeriodSheet()
             }
             .disposed(by: disposeBag)
@@ -91,6 +91,11 @@ final class TimeSelectViewController: UIViewController {
         viewModel.selectedTime
             .map { $0.description }
             .bind(to: timePreviewLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.selectedTime
+            .map { Double($0.start.toSeconds()) }
+            .bind(to: timeRangeSlider.rx.leftValue)
             .disposed(by: disposeBag)
         
         saveButton.rx.tap
@@ -117,7 +122,7 @@ final class TimeSelectViewController: UIViewController {
         
         timeSelectSheet.contentView.addSubview(timeRangeSlider)
         timeRangeSlider.snp.makeConstraints {
-            $0.height.equalToSuperview().multipliedBy(0.08)
+            $0.height.equalToSuperview().multipliedBy(0.1)
             $0.width.equalToSuperview().multipliedBy(0.9)
             $0.centerX.centerY.equalToSuperview()
         }

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RxSwift
+import RxCocoa
 
 final class TimeSelectViewController: UIViewController {
     
@@ -10,18 +11,22 @@ final class TimeSelectViewController: UIViewController {
         return view
     }()
     
-    private let periodSheet: BottomSheet = {
+    private let timeSelectSheet: BottomSheet = {
         let sheet = BottomSheet()
         sheet.backgroundColor = .white
         sheet.roundCorners(20)
         return sheet
     }()
     
-    private let timeSelectView: UIDatePicker = {
-        let datePicker = UIDatePicker()
-        datePicker.locale = Locale(identifier: "ko-KR")
-        datePicker.datePickerMode = .time
-        return datePicker
+    private let timeRangleSlider: RangeSlider = {
+        let slider = RangeSlider(min: 60, max: 60*60*23 + 60*59)
+        return slider
+    }()
+    
+    private let timePreviewLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .lightGray
+        return label
     }()
     
     private lazy var saveButton: UIButton = {
@@ -52,13 +57,13 @@ final class TimeSelectViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
+        
         showPeriodSheet()
     }
     
     private func bind() {
         guard let viewModel = viewModel else { return }
-        
+                
         dimmedView.rx.tapGesture()
             .when(.recognized)
             .withUnretained(self)
@@ -67,21 +72,25 @@ final class TimeSelectViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        periodSheet.rx.swipeGesture(.down)
-            .when(.recognized)
+        timeSelectSheet.rx.swipeGesture(.down)
+            .when(.ended)
             .withUnretained(self)
-            .bind { viewController, _ in
+            .bind { viewController, temp in
                 viewController.hidePeriodSheet()
             }
             .disposed(by: disposeBag)
-        
-        timeSelectView.rx.date
+       
+        timeRangleSlider.rx.leftValue
             .bind(to: viewModel.selectedStartTime)
             .disposed(by: disposeBag)
         
-        timeSelectView.rx.date
-            .compactMap { Calendar.current.date(byAdding: DateComponents(hour:2), to: $0) }
+        timeRangleSlider.rx.rightValue
             .bind(to: viewModel.selectedEndTime)
+            .disposed(by: disposeBag)
+
+        viewModel.selectedTime
+            .map { $0.description }
+            .bind(to: timePreviewLabel.rx.text)
             .disposed(by: disposeBag)
         
         saveButton.rx.tap
@@ -100,19 +109,27 @@ final class TimeSelectViewController: UIViewController {
             $0.top.bottom.leading.trailing.equalToSuperview()
         }
         
-        view.addSubview(periodSheet)
-        periodSheet.snp.makeConstraints {
+        view.addSubview(timeSelectSheet)
+        timeSelectSheet.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.top.equalTo(view.snp.bottom)
         }
         
-        periodSheet.contentView.addSubview(timeSelectView)
-        timeSelectView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalToSuperview().multipliedBy(0.8)
+        timeSelectSheet.contentView.addSubview(timePreviewLabel)
+        timePreviewLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview()
         }
         
-        periodSheet.contentView.addSubview(saveButton)
+        timeSelectSheet.contentView.addSubview(timeRangleSlider)
+        timeRangleSlider.snp.makeConstraints {
+            $0.height.equalTo(60)
+            $0.width.equalToSuperview().multipliedBy(0.7)
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        timeSelectSheet.contentView.addSubview(saveButton)
         saveButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(10)
             $0.centerX.equalToSuperview()
@@ -126,9 +143,9 @@ private extension TimeSelectViewController {
         
         dimmedView.isHidden = false
         isModalInPresentation = true
-
-        periodSheet.move(
-            upTo: view.bounds.height*0.55,
+        
+        timeSelectSheet.move(
+            upTo: view.bounds.height*0.45,
             duration: 0.2,
             animation: self.view.layoutIfNeeded
         )
@@ -139,7 +156,7 @@ private extension TimeSelectViewController {
         
         isModalInPresentation = false
         
-        periodSheet.move(
+        timeSelectSheet.move(
             upTo: view.bounds.height,
             duration: 0.2,
             animation: view.layoutIfNeeded
@@ -149,4 +166,3 @@ private extension TimeSelectViewController {
         }
     }
 }
-

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
@@ -12,7 +12,6 @@ protocol TimeSelectViewModelOutput {
     
     var selectedStartTime: PublishRelay<Date> { get }
     var selectedEndTime: PublishRelay<Date> { get }
-    var selectedTime: PublishRelay<CertifiableTime> { get }
 }
 
 final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOutput {
@@ -21,15 +20,20 @@ final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOu
     let saveButtonTouched = PublishRelay<Void>()
     let selectedStartTime = PublishRelay<Date>()
     let selectedEndTime = PublishRelay<Date>()
-    let selectedTime = PublishRelay<CertifiableTime>()
     
     private let disposeBag = DisposeBag()
     
-    init(navigation: GoalNavigation) {
-        bind(to: navigation)
+    init(
+        navigation: GoalNavigation,
+        with timeStream: PublishRelay<CertifiableTime>
+    ) {
+        bind(to: navigation, with: timeStream)
     }
     
-    func bind(to navigation: GoalNavigation) {
+    func bind(
+        to navigation: GoalNavigation,
+        with timeStream: PublishRelay<CertifiableTime>
+    ) {
         
         closingViewRequested
             .bind(to: navigation.closePeriodSelectView)
@@ -44,7 +48,7 @@ final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOu
         
         saveButtonTouched
             .withLatestFrom(time)
-            .bind(to: selectedTime)
+            .bind(to: timeStream)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
@@ -25,14 +25,14 @@ final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOu
     
     init(
         navigation: GoalNavigation,
-        with timeStream: PublishRelay<CertifiableTime>
+        with timeStream: BehaviorRelay<CertifiableTime>
     ) {
         bind(to: navigation, with: timeStream)
     }
     
     func bind(
         to navigation: GoalNavigation,
-        with timeStream: PublishRelay<CertifiableTime>
+        with timeStream: BehaviorRelay<CertifiableTime>
     ) {
         
         closingViewRequested

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
@@ -36,20 +36,13 @@ final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOu
         to navigation: GoalNavigation,
         with timeStream: BehaviorRelay<CertifiableTime>
     ) {
-  
-        timeStream
-            .bind(to: selectedTime)
-            .disposed(by: disposeBag)
         
         closingViewRequested
             .bind(to: navigation.closePeriodSelectView)
             .disposed(by: disposeBag)
         
         Observable
-            .combineLatest(
-                selectedStartTime.asObservable(),
-                selectedEndTime.asObservable()
-            )
+            .combineLatest( selectedStartTime, selectedEndTime )
             .map { CertifiableTime(start: Int($0), end: Int($1)) }
             .bind(to: selectedTime)
             .disposed(by: disposeBag)

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewModel.swift
@@ -6,20 +6,21 @@ protocol TimeSelectViewModelInput {
     
     var closingViewRequested: PublishRelay<Void> { get }
     var saveButtonTouched: PublishRelay<Void> { get }
+    var selectedStartTime: PublishRelay<Double> { get }
+    var selectedEndTime: PublishRelay<Double> { get }
 }
 
 protocol TimeSelectViewModelOutput {
-    
-    var selectedStartTime: PublishRelay<Date> { get }
-    var selectedEndTime: PublishRelay<Date> { get }
+    var selectedTime: PublishRelay<CertifiableTime> { get }
 }
 
 final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOutput {
     
     let closingViewRequested = PublishRelay<Void>()
     let saveButtonTouched = PublishRelay<Void>()
-    let selectedStartTime = PublishRelay<Date>()
-    let selectedEndTime = PublishRelay<Date>()
+    let selectedStartTime = PublishRelay<Double>()
+    let selectedEndTime = PublishRelay<Double>()
+    let selectedTime = PublishRelay<CertifiableTime>()
     
     private let disposeBag = DisposeBag()
     
@@ -39,15 +40,14 @@ final class TimeSelectViewModel: TimeSelectViewModelInput, TimeSelectViewModelOu
             .bind(to: navigation.closePeriodSelectView)
             .disposed(by: disposeBag)
         
-        let time = Observable.combineLatest(
-                        selectedStartTime.asObservable(),
-                        selectedEndTime.asObservable()
-                    )
-                    .map { CertifiableTime(start: $0, end: $1) }
-                    .share()
+        Observable
+            .combineLatest(selectedStartTime.asObservable(), selectedEndTime.asObservable())
+            .map { CertifiableTime(start: Int($0), end: Int($1)) }
+            .bind(to: selectedTime)
+            .disposed(by: disposeBag)
         
         saveButtonTouched
-            .withLatestFrom(time)
+            .withLatestFrom(selectedTime)
             .bind(to: timeStream)
             .disposed(by: disposeBag)
     }

--- a/rabit/rabit/Utilities/RangeSlider + Reactive.swift
+++ b/rabit/rabit/Utilities/RangeSlider + Reactive.swift
@@ -1,0 +1,23 @@
+import Foundation
+import RxSwift
+import RxCocoa
+
+extension Reactive where Base: RangeSlider {
+    
+    var leftValue: ControlProperty<Double> {
+        base.rx.controlProperty(
+            editingEvents: .valueChanged,
+            getter: { $0.leftValue },
+            setter: { _, _ in }
+        )
+    }
+    
+    var rightValue: ControlProperty<Double> {
+        base.rx.controlProperty(
+            editingEvents: .valueChanged,
+            getter: { $0.rightValue },
+            setter: { _, _ in }
+        )
+    }
+}
+


### PR DESCRIPTION
## 💡 작업 내용
- 이전에 논의한대로 클로저가 아닌 `BehaviorRelay` 를 사용하는 방식으로 수정
- `RangleSlider` 구현 후, rx extension을 적용해서 선택한 시간의 시작과 끝 값을 바인딩
- `Double`값을 `TimeComponents`로 변환해서 시,분,초를 각각 계산 후 `CertifiableTime` 값으로 변환해서 다른 뷰모델로 전달

## 💡 고민사항
### 1) 사용자 정의 이벤트(UIControl.Event) 관련
- 현재 구현한 커스텀슬라이더에서, 터치 이벤트를 처리할 때 .valueChanged에 대해서 이벤트를 처리하고 있고, 슬라이더가 내부적으로 가지고 있는 버튼이 2개고, 뷰모델에서도 각 버튼이 가리키는 값에 대응되는 시작과 끝 시간에 해당하는 값을 각각 Subject로 가지고 있습니다.
```swift
sendActions(for: .valueChanged)

//뷰컨트롤러에서의 슬라이더와 뷰모델 간 rx 바인딩
timeRangeSlider.rx.leftValue
    .bind(to: viewModel.selectedStartTime)
    .disposed(by: disposeBag)

timeRangeSlider.rx.rightValue
    .bind(to: viewModel.selectedEndTime)
    .disposed(by: disposeBag)
```
- 문제는 왼쪽 버튼은 그대로 두고, 오른쪽 버튼을 터치했을 때 `rightValue` 뿐만 아니라  `leftValue` 에 대한 .valueChanged 액션도 동시에 발생해서, 기존에 의도한대로 1개의 이벤트만 방출하는 것이 아닌 매번 불필요하게 2개의 이벤트를 항상 방출하는 상황이 발생합니다.
- `.valueChanged` 를 사용하지 않고 `UIControl.Event` 에 leftValueChanged, rightValueChanged.. 이런식으로 커스텀 이벤트를 따로 정의해서, 슬라이더 내부에서 isLeftThumTouched 속성값에 따라 각각 다른 이벤트를 `sendAction(for:)` 하도록 했으나 이럴 경우에는 rx extension에 정의된 코드가 제대로 동작하지 않습니다. 
``` swift
// 커스텀 이벤트 정의
extension UIControl.Event {   
    static var leftValueChanged: UIControl.Event {  UIControl.Event() }
    static var rightValueChanged: UIControl.Event {  UIControl.Event() }
}

extension Reactive where Base: RangeSlider {
    
    var leftValue: ControlProperty<Double> {
        base.rx.controlProperty(
            editingEvents: .leftValueChanged, // 기존에는 .valueChanged로 명시
            getter: { $0.leftValue },
            setter: { _, _ in }
        )
    }
    
    var rightValue: ControlProperty<Double> {
        base.rx.controlProperty(
            editingEvents: .rightValueChanged,  // 기존에는 .valueChanged로 명시
            getter: { $0.rightValue },
            setter: { _, _ in }
        )
    }
}
```
- 우선은 .valueChanged를 그대로 둬서 기능은 제대로 동작하게 했지만, 아무런 변화가 없다면 불필요하게 이벤트를 방출할 필요가 없을 것 같아서 추후 따로 정의한 UIControl.Event 타입 속성이 제대로 동작하도록 하는 법을 찾아서 적용해보려 합니다!
    
### 2) 기존에 선택된 시간 관련 값을, TimeSelectViewController 화면을 띄웠을 때 초기값으로 보여주기
- 기존에 솔이 구현한 ColorPickerViewController과 마찬가지로, 기존에 선택한 값을 기억해뒀다 화면을 띄울 때 초기값으로 보여주려 하는데 잘 적용이 안되네요 ㅋㅋ
- 대강 아래처럼 뷰모델의 생성자로 받은 timeStream 파라미터값을 그대로 바인딩 메소드로 넘겨서 맨 처음에 selectedTime 속성에 바인딩 시키고, 뷰컨트롤러에서는 슬라이더를 바인딩된 뷰모델의 selectedTime 속성값을 읽어들여 다시 바인딩하는 과정을 생각했어요!
```swift
 func bind(
        to navigation: GoalNavigation,
        with timeStream: BehaviorRelay<CertifiableTime>
    ) {
  
        timeStream
            .bind(to: selectedTime)
            .disposed(by: disposeBag)
     }   
```
- 제가 생각하는 문제는 일단 커스텀 슬라이더 내부에서 layoutSubViews()를 아래처럼 오버라이딩하고 있는데 이게 문제인건가 막연하게 생각하고 있습니다.
    - RangeSlider 내부에 leftValue, rightValue 라는 속성을 정의했는데 이것의 초기값이 생성자로 받는 minValue, maxValue 값으로 각각 세팅되있어서 TimeSelectViewModel에서 어떻게 바인딩되는 지에 상관 없이 RangeSlider의 leftValue, rightValue의 초기값은 항상 정해져있기 때문에 고정된 상태로 보이는게 아닐까,, 생각하고 있어요 
```swift
    override func layoutSubviews() {
        super.layoutSubviews()
        // 현재 leftValue, rightValue의 값에 맞춰서 버튼의 위치를 변경
        updateLayout(to: rightValue, direction: .right)
        updateLayout(to: leftValue, direction: .left)
    }
```
- 우선은 이 부분도 레이아웃 그리는 방식과 바인딩 순서를 한 번 다시 정리해보고 어떻게 흐름을 맞출 지 생각해보려 합니다!

## 💡 미리보기
<img src="https://user-images.githubusercontent.com/68586291/188535401-fe1bd6c9-3d12-4914-aa28-a598ad64336d.gif" style="width: 20%;"/>
