### PR TITLE
ColorPickerView를 BottomSheet으로 변경 및 PhotoEdit, ColorPicker의 저장 버튼 기능 구현

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0232BD9528AE11DD009057F8 /* ColorPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9428AE11DD009057F8 /* ColorPickerViewModel.swift */; };
 		0232BD9728AE5C3D009057F8 /* UIColor + Initializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9628AE5C3D009057F8 /* UIColor + Initializer.swift */; };
 		0232BD9928AF6B25009057F8 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9828AF6B25009057F8 /* Photo.swift */; };
+		02376F5028C60ED40091D1B6 /* UIButton + setBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */; };
 		02520987289A5A2400E7E604 /* AlbumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02520986289A5A2400E7E604 /* AlbumViewController.swift */; };
 		02520989289A5C1D00E7E604 /* AlbumCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02520988289A5C1D00E7E604 /* AlbumCell.swift */; };
 		0252098F289A661E00E7E604 /* AlbumHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0252098E289A661E00E7E604 /* AlbumHeaderView.swift */; };
@@ -103,6 +104,7 @@
 		0232BD9428AE11DD009057F8 /* ColorPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerViewModel.swift; sourceTree = "<group>"; };
 		0232BD9628AE5C3D009057F8 /* UIColor + Initializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Initializer.swift"; sourceTree = "<group>"; };
 		0232BD9828AF6B25009057F8 /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton + setBackgroundColor.swift"; sourceTree = "<group>"; };
 		02520986289A5A2400E7E604 /* AlbumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumViewController.swift; sourceTree = "<group>"; };
 		02520988289A5C1D00E7E604 /* AlbumCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCell.swift; sourceTree = "<group>"; };
 		0252098E289A661E00E7E604 /* AlbumHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumHeaderView.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				02B916DA28B89ADF0086F29E /* RealmResults + toArray.swift */,
 				B57D75F328B3E76300C11405 /* UIView + shadow.swift */,
 				B582573D28BDF718001AE268 /* Date + toDateComponent, toTimeComponent.swift */,
+				02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */,
 				B56AF75128C6528B001C82C0 /* RangeSlider + Reactive.swift */,
 			);
 			path = Utilities;
@@ -631,6 +634,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02DB2F8728AC9115005938CB /* PhotoEditViewModel.swift in Sources */,
+				02376F5028C60ED40091D1B6 /* UIButton + setBackgroundColor.swift in Sources */,
 				B5D131CE289A04F200EE1833 /* Coordinator.swift in Sources */,
 				B582574628BF3323001AE268 /* CertifiableTime.swift in Sources */,
 				B58EF87728B8BABC0075B295 /* BottomSheet.swift in Sources */,

--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0232BD9528AE11DD009057F8 /* ColorPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9428AE11DD009057F8 /* ColorPickerViewModel.swift */; };
 		0232BD9728AE5C3D009057F8 /* UIColor + Initializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9628AE5C3D009057F8 /* UIColor + Initializer.swift */; };
 		0232BD9928AF6B25009057F8 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232BD9828AF6B25009057F8 /* Photo.swift */; };
+		02376F5028C60ED40091D1B6 /* UIButton + setBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */; };
 		02520987289A5A2400E7E604 /* AlbumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02520986289A5A2400E7E604 /* AlbumViewController.swift */; };
 		02520989289A5C1D00E7E604 /* AlbumCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02520988289A5C1D00E7E604 /* AlbumCell.swift */; };
 		0252098F289A661E00E7E604 /* AlbumHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0252098E289A661E00E7E604 /* AlbumHeaderView.swift */; };
@@ -101,6 +102,7 @@
 		0232BD9428AE11DD009057F8 /* ColorPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerViewModel.swift; sourceTree = "<group>"; };
 		0232BD9628AE5C3D009057F8 /* UIColor + Initializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Initializer.swift"; sourceTree = "<group>"; };
 		0232BD9828AF6B25009057F8 /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton + setBackgroundColor.swift"; sourceTree = "<group>"; };
 		02520986289A5A2400E7E604 /* AlbumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumViewController.swift; sourceTree = "<group>"; };
 		02520988289A5C1D00E7E604 /* AlbumCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCell.swift; sourceTree = "<group>"; };
 		0252098E289A661E00E7E604 /* AlbumHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumHeaderView.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				02B916DA28B89ADF0086F29E /* RealmResults + toArray.swift */,
 				B57D75F328B3E76300C11405 /* UIView + shadow.swift */,
 				B582573D28BDF718001AE268 /* Date + toDateComponent, toTimeComponent.swift */,
+				02376F4F28C60ED40091D1B6 /* UIButton + setBackgroundColor.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02DB2F8728AC9115005938CB /* PhotoEditViewModel.swift in Sources */,
+				02376F5028C60ED40091D1B6 /* UIButton + setBackgroundColor.swift in Sources */,
 				B5D131CE289A04F200EE1833 /* Coordinator.swift in Sources */,
 				B582574628BF3323001AE268 /* CertifiableTime.swift in Sources */,
 				B58EF87728B8BABC0075B295 /* BottomSheet.swift in Sources */,

--- a/rabit/rabit/Album/AlbumCoordinator.swift
+++ b/rabit/rabit/Album/AlbumCoordinator.swift
@@ -5,13 +5,14 @@ import RxRelay
 protocol AlbumNavigation {
     var showPhotoEditView: PublishRelay<Album.Item> { get }
     var closeColorPickerView: PublishRelay<Void> { get }
-    var closePhotoEditView: PublishRelay<Void> { get }
+    var saveUpdatedPhoto: PublishRelay<Void> { get }
 }
 
 protocol PhotoEditNavigation {
     var showColorPickerView: PublishRelay<BehaviorRelay<String>> { get }
     var showStylePickerView: PublishRelay<Void> { get }
     var closePhotoEditView: PublishRelay<Void> { get }
+    var saveUpdatedPhoto: PublishRelay<Void> { get }
 }
 
 protocol ColorPickerNavigation {
@@ -29,6 +30,7 @@ final class AlbumCoordinator: Coordinator, PhotoEditNavigation, AlbumNavigation,
     let showColorPickerView = PublishRelay<BehaviorRelay<String>>()
     let showStylePickerView = PublishRelay<Void>()
     let closePhotoEditView = PublishRelay<Void>()
+    let saveUpdatedPhoto = PublishRelay<Void>()
     let closeColorPickerView = PublishRelay<Void>()
     let saveSelectedColor = PublishRelay<Void>()
 
@@ -99,6 +101,10 @@ private extension AlbumCoordinator {
             .disposed(by: disposeBag)
 
         closePhotoEditView
+            .bind(onNext: dismissPhotoEditView)
+            .disposed(by: disposeBag)
+
+        saveUpdatedPhoto
             .bind(onNext: dismissPhotoEditView)
             .disposed(by: disposeBag)
 

--- a/rabit/rabit/Album/AlbumViewModel.swift
+++ b/rabit/rabit/Album/AlbumViewModel.swift
@@ -47,7 +47,7 @@ private extension AlbumViewModel {
             .bind(to: navigation.showPhotoEditView)
             .disposed(by: disposeBag)
 
-        navigation.closePhotoEditView
+        navigation.saveUpdatedPhoto
             .bind(to: requestAlbumData)
             .disposed(by: disposeBag)
     }

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
@@ -2,8 +2,23 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import RxGesture
 
 final class ColorPickerViewController: UIViewController {
+    private let dimmedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black.withAlphaComponent(0.6)
+        view.isHidden = true
+        return view
+    }()
+
+    private let colorSheet: BottomSheet = {
+        let sheet = BottomSheet()
+        sheet.backgroundColor = .white
+        sheet.roundCorners(20)
+        return sheet
+    }()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 20, weight: .semibold)
@@ -17,6 +32,17 @@ final class ColorPickerViewController: UIViewController {
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
         return collectionView
+    }()
+
+    private let saveButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("저장", for: .normal)
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.backgroundColor = UIColor(named: "third")
+        button.roundCorners()
+        return button
     }()
 
 
@@ -33,32 +59,50 @@ final class ColorPickerViewController: UIViewController {
         super.viewDidLoad()
 
         setupViews()
-        setAttributes()
         setupPresetColorCollectionView()
         bind()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        showColorSheet()
     }
 }
 
 private extension ColorPickerViewController {
     func setupViews() {
-        view.addSubview(titleLabel)
-        view.addSubview(presetColorCollectionView)
+        view.addSubview(dimmedView)
+        dimmedView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
 
+        view.addSubview(colorSheet)
+        colorSheet.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(view.snp.bottom)
+        }
+
+        colorSheet.contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(100)
+            make.top.equalToSuperview().offset(20)
             make.leading.equalToSuperview().offset(20)
         }
 
+        colorSheet.contentView.addSubview(presetColorCollectionView)
         presetColorCollectionView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(20)
             make.leading.equalToSuperview().offset(20)
-            make.trailing.bottom.equalToSuperview().inset(20)
+            make.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(220)
         }
-    }
 
-    func setAttributes() {
-        view.backgroundColor = UIColor(named: "first")
-        setupNavigationBarButton()
+        colorSheet.contentView.addSubview(saveButton)
+        saveButton.snp.makeConstraints { make in
+            make.top.equalTo(presetColorCollectionView.snp.bottom).offset(20)
+            make.leading.equalToSuperview().offset(20)
+            make.trailing.equalToSuperview().inset(20)
+        }
     }
 
     func bind() {
@@ -93,15 +137,34 @@ private extension ColorPickerViewController {
             .bind(to: viewModel.selectedColor)
             .disposed(by: disposeBag)
 
-        navigationItem.leftBarButtonItem?.rx.tap
-            .bind(to: viewModel.backButtonTouched)
+        dimmedView.rx.tapGesture()
+            .when(.recognized)
+            .withUnretained(self)
+            .bind(onNext: { viewController, _ in
+                viewController.hideColorSheet(target: viewModel.closeColorPickerRequested)
+            })
+            .disposed(by: disposeBag)
+
+        colorSheet.rx.swipeGesture(.down)
+            .when(.recognized)
+            .withUnretained(self)
+            .bind(onNext: { viewController, _ in
+                viewController.hideColorSheet(target: viewModel.closeColorPickerRequested)
+            })
+            .disposed(by: disposeBag)
+
+        saveButton.rx.tap
+            .withUnretained(self)
+            .bind(onNext: { viewController, _ in
+                viewController.hideColorSheet(target: viewModel.saveButtonTouched)
+            })
             .disposed(by: disposeBag)
     }
 
     func setupPresetColorCollectionView() {
         let layout = CompositionalLayoutFactory.shared.create(
-            widthFraction: 1/6,
-            heightFraction: 1/6,
+            widthFraction: 1/5,
+            heightFraction: 1/5,
             spacing: Spacing(top: 5, bottom: 5, left: 5, right: 5)
         )
 
@@ -113,16 +176,26 @@ private extension ColorPickerViewController {
         )
     }
 
-    func setupNavigationBarButton() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            image: UIImage(
-                systemName: "chevron.backward",
-                withConfiguration: UIImage.SymbolConfiguration(
-                    pointSize: 18,
-                    weight: .semibold)
-                ),
-            style: .plain,
-            target: nil, action: nil
+    func showColorSheet() {
+        dimmedView.isHidden = false
+
+        colorSheet.move(
+            upTo: view.bounds.height*0.5,
+            duration: 0.2,
+            animation: view.layoutIfNeeded
         )
+
+        navigationController?.hidesBottomBarWhenPushed = true
+    }
+    
+    func hideColorSheet(target: PublishRelay<Void>) {
+        colorSheet.move(
+            upTo: view.bounds.height,
+            duration: 0.2,
+            animation: view.layoutIfNeeded
+        ) { _ in
+            self.dimmedView.isHidden = true
+            target.accept(())
+        }
     }
 }

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
@@ -40,8 +40,9 @@ final class ColorPickerViewController: UIViewController {
         button.titleLabel?.textAlignment = .center
         button.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
         button.setTitleColor(UIColor.white, for: .normal)
-        button.backgroundColor = UIColor(named: "third")
         button.roundCorners()
+        button.setBackgroundColor(UIColor(named: "third"), for: .normal)
+        button.setBackgroundColor(.systemGray3, for: .disabled)
         return button
     }()
 
@@ -102,6 +103,7 @@ private extension ColorPickerViewController {
             make.top.equalTo(presetColorCollectionView.snp.bottom).offset(20)
             make.leading.equalToSuperview().offset(20)
             make.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(50)
         }
     }
 

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewController.swift
@@ -159,6 +159,10 @@ private extension ColorPickerViewController {
                 viewController.hideColorSheet(target: viewModel.saveButtonTouched)
             })
             .disposed(by: disposeBag)
+
+        viewModel.saveButtonState
+            .bind(to: saveButton.rx.isEnabled)
+            .disposed(by: disposeBag)
     }
 
     func setupPresetColorCollectionView() {

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
@@ -10,6 +10,7 @@ protocol ColorPickerViewModelInput {
 
 protocol ColorPickerViewModelOutput {
     var presetColors: [String] { get }
+    var saveButtonState: BehaviorRelay<Bool> { get }
 }
 
 protocol ColorPickerViewModelProtocol: ColorPickerViewModelInput, ColorPickerViewModelOutput { }
@@ -18,6 +19,7 @@ final class ColorPickerViewModel: ColorPickerViewModelProtocol {
     let selectedColor: BehaviorRelay<String>
     let closeColorPickerRequested = PublishRelay<Void>()
     let saveButtonTouched = PublishRelay<Void>()
+    let saveButtonState = BehaviorRelay<Bool>(value: false)
     let presetColors = [
         "#E4B6BC", "#E09681", "#000000",
         "#FFFFFF", "#003865", "#3BCF4E",
@@ -43,6 +45,13 @@ private extension ColorPickerViewModel {
     func bind(to colorStream: BehaviorRelay<String>) {
         saveButtonTouched.withLatestFrom(selectedColor)
             .bind(to: colorStream)
+            .disposed(by: disposeBag)
+
+        selectedColor
+            .map {
+                $0 != colorStream.value
+            }
+            .bind(to: saveButtonState)
             .disposed(by: disposeBag)
     }
 

--- a/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
+++ b/rabit/rabit/Album/ColorPicker/ColorPickerViewModel.swift
@@ -4,7 +4,8 @@ import RxRelay
 
 protocol ColorPickerViewModelInput {
     var selectedColor: BehaviorRelay<String> { get }
-    var backButtonTouched: PublishSubject<Void> { get }
+    var closeColorPickerRequested: PublishRelay<Void> { get }
+    var saveButtonTouched: PublishRelay<Void> { get }
 }
 
 protocol ColorPickerViewModelOutput {
@@ -15,7 +16,8 @@ protocol ColorPickerViewModelProtocol: ColorPickerViewModelInput, ColorPickerVie
 
 final class ColorPickerViewModel: ColorPickerViewModelProtocol {
     let selectedColor: BehaviorRelay<String>
-    let backButtonTouched = PublishSubject<Void>()
+    let closeColorPickerRequested = PublishRelay<Void>()
+    let saveButtonTouched = PublishRelay<Void>()
     let presetColors = [
         "#E4B6BC", "#E09681", "#000000",
         "#FFFFFF", "#003865", "#3BCF4E",
@@ -39,14 +41,18 @@ final class ColorPickerViewModel: ColorPickerViewModelProtocol {
 
 private extension ColorPickerViewModel {
     func bind(to colorStream: BehaviorRelay<String>) {
-        selectedColor
+        saveButtonTouched.withLatestFrom(selectedColor)
             .bind(to: colorStream)
             .disposed(by: disposeBag)
     }
 
     func bind(to navigation: ColorPickerNavigation) {
-        backButtonTouched
+        closeColorPickerRequested
             .bind(to: navigation.closeColorPickerView)
+            .disposed(by: disposeBag)
+
+        saveButtonTouched
+            .bind(to: navigation.saveSelectedColor)
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Album/Models/Photo.swift
+++ b/rabit/rabit/Album/Models/Photo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Photo {
+struct Photo: Equatable {
     let uuid: UUID
     let categoryTitle: String
     let goalTitle: String

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -30,6 +30,19 @@ final class PhotoEdtiViewController: UIViewController {
         return button
     }()
 
+    private let cancelButton: UIBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .close,
+        target: nil,
+        action: nil
+    )
+
+    private let saveButton: UIBarButtonItem = UIBarButtonItem(
+        title: "저장",
+        style: .done,
+        target: nil,
+        action: nil
+    )
+
     private var viewModel: PhotoEditViewModelProtocol?
 
     private var disposeBag = DisposeBag()
@@ -114,24 +127,23 @@ private extension PhotoEdtiViewController {
             .bind(to: viewModel.stylePickerButtonTouched)
             .disposed(by: disposeBag)
 
-        navigationItem.leftBarButtonItem?.rx.tap
+        cancelButton.rx.tap
             .bind(to: viewModel.backButtonTouched)
             .disposed(by: disposeBag)
 
-        navigationItem.rightBarButtonItem?.rx.tap
+        saveButton.rx.tap
             .bind(to: viewModel.saveButtonTouched)
+            .disposed(by: disposeBag)
+
+        viewModel.saveButtonState
+            .bind(to: saveButton.rx.isEnabled)
             .disposed(by: disposeBag)
     }
 
     func setNavigationBarButton() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .close,
-            target: self,
-            action: nil
-        )
+        navigationItem.leftBarButtonItem = cancelButton
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "저장", style: .done, target: self, action: nil)
-
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(named: "second")
+        navigationItem.rightBarButtonItem = saveButton
+        saveButton.tintColor = UIColor(named: "second")
     }
 }

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import RxGesture
 
 final class PhotoEdtiViewController: UIViewController {
     private let photoImageView: UIImageView = {
@@ -116,18 +117,21 @@ private extension PhotoEdtiViewController {
         navigationItem.leftBarButtonItem?.rx.tap
             .bind(to: viewModel.backButtonTouched)
             .disposed(by: disposeBag)
+
+        navigationItem.rightBarButtonItem?.rx.tap
+            .bind(to: viewModel.saveButtonTouched)
+            .disposed(by: disposeBag)
     }
 
     func setNavigationBarButton() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            image: UIImage(
-                systemName: "chevron.backward",
-                withConfiguration: UIImage.SymbolConfiguration(
-                    pointSize: 18,
-                    weight: .semibold)
-                ),
-            style: .plain,
-            target: nil, action: nil
+            barButtonSystemItem: .close,
+            target: self,
+            action: nil
         )
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "저장", style: .done, target: self, action: nil)
+
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(named: "second")
     }
 }

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -15,8 +15,8 @@ final class PhotoEdtiViewController: UIViewController {
         button.setTitle("글씨 색깔 변경", for: .normal)
         button.setImage(UIImage(systemName: "paintpalette"), for: .normal)
         button.tintColor = UIColor.white
-        button.backgroundColor = UIColor(named: "second")
         button.roundCorners()
+        button.setBackgroundColor(UIColor(named: "second"), for: .normal)
         return button
     }()
 
@@ -25,8 +25,8 @@ final class PhotoEdtiViewController: UIViewController {
         button.setTitle("글씨 스타일 변경", for: .normal)
         button.setImage(UIImage(systemName: "scribble"), for: .normal)
         button.tintColor = UIColor.white
-        button.backgroundColor = UIColor(named: "second")
         button.roundCorners()
+        button.setBackgroundColor(UIColor(named: "second"), for: .normal)
         return button
     }()
 

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewModel.swift
@@ -6,6 +6,7 @@ protocol PhotoEditViewModelInput {
     var colorPickerButtonTouched: PublishRelay<Void> { get }
     var stylePickerButtonTouched: PublishRelay<Void> { get }
     var backButtonTouched: PublishRelay<Void> { get }
+    var saveButtonTouched: PublishRelay<Void> { get }
     var hexPhotoColor: BehaviorRelay<String> { get }
 }
 
@@ -19,6 +20,7 @@ final class PhotoEditViewModel: PhotoEditViewModelProtocol {
     let colorPickerButtonTouched = PublishRelay<Void>()
     let stylePickerButtonTouched = PublishRelay<Void>()
     let backButtonTouched = PublishRelay<Void>()
+    let saveButtonTouched = PublishRelay<Void>()
     let hexPhotoColor: BehaviorRelay<String>
     let selectedPhotoData = BehaviorSubject<Album.Item>(
         value: Album.Item(
@@ -59,7 +61,11 @@ private extension PhotoEditViewModel {
             .bind(to: navigation.showStylePickerView)
             .disposed(by: disposeBag)
 
-        backButtonTouched.withLatestFrom(selectedPhotoData)
+        backButtonTouched
+            .bind(to: navigation.closePhotoEditView)
+            .disposed(by: disposeBag)
+
+        saveButtonTouched.withLatestFrom(selectedPhotoData)
             .withUnretained(self)
             .bind(onNext: { viewModel, data in
                 viewModel.albumRepository.updateAlbumData(data)

--- a/rabit/rabit/Utilities/UIButton + setBackgroundColor.swift
+++ b/rabit/rabit/Utilities/UIButton + setBackgroundColor.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+extension UIButton {
+    func setBackgroundColor(_ color: UIColor?, for state: UIControl.State) {
+        UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
+
+        guard let context = UIGraphicsGetCurrentContext(),
+              let color = color else { return }
+
+        context.setFillColor(color.cgColor)
+        context.fill(CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0))
+
+        let backgroundImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        self.setBackgroundImage(backgroundImage, for: state)
+    }
+}


### PR DESCRIPTION
## 진행 내용
- ColorPickerView를 BottomSheet으로 구현
- ColorPickerView와 PhotoEditView에 **저장** 버튼 구현
- 두 저장 버튼의 `Enable` 상태 기능 구현
- UIButton을 extension하여 `setBackgroundColor(_:for:)` 메소드 구현
    - 버튼의 상태에 따른 배경색 설정할 수 있는 메소드

## 고민했던 부분
### 1. Album -> PhotoEdit 화면 전환시에 PhotoStream에 해당하는 Observable value 넘겨주기
- **AlbumViewModelInput**에 정의되어 있는 `photoSelected: PublishRelay<Album.Item>` 프로퍼티는 앨범 컬렉션뷰의 Cell이 터치됐을 때 해당 Cell에 할당되어 있는 모델 타입을 받는 프로퍼티입니다.
- 그리고 CollectionView의 특성상 Cell이 터치되면 즉시 화면 전환이 요구되므로, 해당 프로퍼티와 Navigation 관련 로직이 바인딩되어있습니다.
- 다른 화면에서 구현했던 바와 같이, Navigation이 발생할 때 해당 프로퍼티를 넘겨주어 Stream을 구현하고 싶었습니다.
- 따라서 아래와 같은 시도를 했습니다.
    1. photoSelected 프로퍼티를 BehaviorRelay로 타입을 수정하고 Navigation 발생 시에 해당 프로퍼티를 넘깁니다.
    2. 그러면 해당 프로퍼티를 받은 PhotoEditViewModel에서는 해당 프로퍼티를 특정 Observable 프로퍼티에 바인딩합니다.
    3. PhotoEditViewModel의 프로퍼티는 UI에 바인딩되어있는 Observable 프로퍼티이기 때문에 BehaviorRelay 타입입니다. 따라서 해당 바인딩 과정에서 photoSelected 프로퍼티는 이벤트를 방출받습니다.
    4. 이로 인해, photoSelected와 바인딩되어 있던 Navigation 관련 로직이 트리거되어, Cell 터치가 없더라도 PhotoEditView가 화면에 나타나는 문제가 발생합니다.
- 여러 레퍼런스를 3일동안 찾아봤지만, 명확한 레퍼런스를 찾기는 어려웠고, `RxController`라는 라이브러리를 찾았는데 해당 라이브러리는 `MVVM-C with RxFlow & RxSwift`를 위한 라이브러리입니다. 해당 라이브러리에서는 ViewModel간 데이터 전달이 필요한 상황에서는 Observable 프로퍼티가 아닌 모델에 해당하는 프로퍼티를 주고 받습니다.
- 그래서 제가 내린 결론은, ViewModel간 주로 모델을 주고 받고, Stream을 주고 받는 상황이 필요할 때에는 지금처럼 Observable value를 주고 받는게 맞겠다는 것입니다. 
    독립적인 ViewModel간 Stream이 필요한 경우에는 따로 레퍼런스를 찾지 못하기도 했고, 보통(Coordinator를 사용하지 않을 때)은 뷰모델이 하위 뷰모델을 가지면서 부모 뷰모델이 하위 뷰모델에 직접적으로 데이터 바인딩을 해주는 경우가 많았기 때문에, MVVM-C를 사용하는 환경에서는 저희가 선택한 `PublishRelay<BehaviorRelay<...>>` 와 같은 로직이 가장 적합하지 않나 생각했습니다.

### 2. Coordinator에서 모든 Navigation들을 `UINavigationController.pushViewController(_:animated:)`로 처리하기
- Coordinator들의 navigation 로직 중 공통 부분을 만들어 `protocol extension`을 이용해 줄일 수 있는 메소드들을 줄이고 싶었고, Coordinator가 navigationController를 가지고 있기 때문에 모든 VC들을 관리하기 위해서는 `push&pop`만을 사용하는게 Coordinator 패턴에 적합한 네비게이션 방법이라 생각했습니다.
- 기존에는 PhotoEditVC, ColorPickerVC 모두 `present(_:animated:)` 메소드로 네이베이션하는 상태입니다.
- 그래서 PhotoEditVC부터 `push`를 사용해 화면에 띄워보았습니다.
    그랬더니 PhotoEditVC에서 ColorPickerVC를 띄웠을 때에 아래에 TabBar가 남겨져 있게 되었고, ColorPickerVC를 보는 상태에서 TabBar의 다른 Tab으로 이동했다가 돌아오면 ColorPickerVC 아래에 보여야할 PhotoEditVC가 보이지 않는 상태가 되어있었습니다.
    <img src="https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202209070156950.gif" alt="SS2022-09-07AM01.55.56" width="30%;" />

- 다음 시도로 ColorPickerVC도 `push`를 사용해 화면에 띄워보았습니다.
    이렇게되면, ColorPickerVC로 이동했을 때 PhotoEditVC는 안보이는 상태가 되기 때문에 BottomSheet을 이용하는게 의미없어졌습니다.
    <img src="https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202209070158502.jpg" alt="SS2022-09-07AM01.58.39" width="30%;" />
- 일단 ColorPickerVC는 다시 `present`로 띄우도록 돌려놓고, 앞서 말했던 문제인 TabBar가 보여서 발생하는 문제를 해결하기 위해 아래의 코드를 Coordinator의 메소드 내에서 실행시켜 TabBar를 숨겼습니다.
    ```swift
    navigationController.tabBarController?.tabBar.isHidden = true
    ```
    이걸로 문제를 해결할 수는 있었지만, 이렇게 예외가 발생하게 되면 초기에 생각했던 `protocol extension`을 사용하여 코드를 줄이는 방법을 사용할 수 없게 되므로, TabBar를 숨기는 코드를 ColorPickerVC의 `viewWillAppear` 메소드에서 실행해보았지만, 해당 VC는 NavigationController에 속한 VC가 아니기 때문에 해당 코드가 실행되지 않았습니다.

- 이번에도 마찬가지로, 어쩔 수 없이 `present`를 사용할 수 밖에 없겠다는 결론에 다다랐습니다..


> merge conflict가 발생할 것 같아 rebase를 하는 과정에서 동일 커밋이 2번 되었습니다. 해당 부분 감안하고 봐주시면 감사하겠습니다ㅎㅎ