### PR TITLE
BottomSheet 화면 내려가는 UX 개선

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		B5D34DB328C9B8DF00F04070 /* DaySelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D34DB228C9B8DF00F04070 /* DaySelectCell.swift */; };
 		B5D34DB528CA07E200F04070 /* Days.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D34DB428CA07E200F04070 /* Days.swift */; };
 		B5D7603128A37D630046B09C /* GoalListCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D7603028A37D630046B09C /* GoalListCollectionViewHeader.swift */; };
+		B5F37E6C28E5DA92007FF5E5 /* BottomSheet + Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -185,6 +186,7 @@
 		B5D34DB228C9B8DF00F04070 /* DaySelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaySelectCell.swift; sourceTree = "<group>"; };
 		B5D34DB428CA07E200F04070 /* Days.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Days.swift; sourceTree = "<group>"; };
 		B5D7603028A37D630046B09C /* GoalListCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalListCollectionViewHeader.swift; sourceTree = "<group>"; };
+		B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BottomSheet + Reactive.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -335,6 +337,7 @@
 				B56AF75128C6528B001C82C0 /* RangeSlider + Reactive.swift */,
 				02D30E6C28C86AB100B5C4B2 /* String + strikeThrough.swift */,
 				02D30E7828C87EDE00B5C4B2 /* DateConverter.swift */,
+				B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -734,6 +737,7 @@
 				B5D131E2289C2A1B00EE1833 /* GoalProgressView.swift in Sources */,
 				B5D131D6289A0D6B00EE1833 /* GoalCoordinator.swift in Sources */,
 				0232BD9528AE11DD009057F8 /* ColorPickerViewModel.swift in Sources */,
+				B5F37E6C28E5DA92007FF5E5 /* BottomSheet + Reactive.swift in Sources */,
 				02F37254289E1EA200F361C7 /* PaddingLabel.swift in Sources */,
 				B5D131E8289C2D1100EE1833 /* Category.swift in Sources */,
 				B5D34DB328C9B8DF00F04070 /* DaySelectCell.swift in Sources */,

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -11,17 +11,65 @@ final class BottomSheet: UIControl {
     }()
     
     let contentView = UIView()
+    private var minTopOffset: CGFloat = .zero
+    private var maxTopOffset: CGFloat = .zero
     private var closeFlag = false {
-        didSet { sendActions(for: .valueChanged) }
+        didSet { if closeFlag { sendActions(for: .valueChanged) } }
+    }
+    
+    convenience init(_ maxTopOffset: CGFloat, _ minTopOffset: CGFloat) {
+        self.init()
+        self.maxTopOffset = maxTopOffset
+        self.minTopOffset = minTopOffset
+        setupViews()
+        addPanGestureRecognizer()
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        addPanGestureRecognizer()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hitView = super.hitTest(point, with: event)
+        return hitView == self ? nil : hitView
+    }
+    
+    private func addPanGestureRecognizer() {
+        let recognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))
+        addGestureRecognizer(recognizer)
+    }
+    
+    @objc private func didPan(_ recognizer: UIPanGestureRecognizer) {
+        //이동된 y 거리 계산
+        let updatedY = frame.minY + recognizer.translation(in: self).y
+        
+        //updatedY의 범위가 기존의 topOffset 이하인 지 판벼
+        if (minTopOffset...maxTopOffset) ~= updatedY {
+            updateConstraints(updatedY)
+            recognizer.setTranslation(.zero, in: self)
+        }
+        UIView.animate(withDuration: 0.0, delay: .zero, animations: layoutIfNeeded)
+        
+        //recognizer이 끝났을 때 상태 업데이트
+        guard recognizer.state == .ended else { return }
+        let isDownward = recognizer.velocity(in: self).y > 0
+        let yPosition: CGFloat = updatedY > maxTopOffset*0.7 ? maxTopOffset : updatedY
+
+        if isDownward {
+            updateConstraints(yPosition)
+        } else {
+            updateConstraints(minTopOffset)
+        }
+        
+        if yPosition >= maxTopOffset {
+            closeFlag = true
+        }
     }
     
     private func setupViews() {

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -3,6 +3,7 @@ import SnapKit
 
 final class BottomSheet: UIControl {
     
+    private let topBarArea: UIView = UIView()
     private let topBar: UIView = {
         let view = UIView()
         view.backgroundColor = .systemGray5
@@ -42,7 +43,7 @@ final class BottomSheet: UIControl {
     
     private func addPanGestureRecognizer() {
         let recognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))
-        addGestureRecognizer(recognizer)
+        topBarArea.addGestureRecognizer(recognizer)
     }
     
     @objc private func didPan(_ recognizer: UIPanGestureRecognizer) {
@@ -69,22 +70,27 @@ final class BottomSheet: UIControl {
         
         if yPosition >= maxTopOffset {
             closeFlag = true
-        }
+        }        
     }
     
     private func setupViews() {
         
-        addSubview(topBar)
+        addSubview(topBarArea)
+        topBarArea.snp.makeConstraints {
+            $0.left.right.top.equalToSuperview()
+            $0.height.equalTo(21)
+        }
+        
+        topBarArea.addSubview(topBar)
         topBar.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview().multipliedBy(0.08)
+            $0.centerX.centerY.equalToSuperview()
             $0.width.equalToSuperview().multipliedBy(0.5)
             $0.height.equalTo(7)
         }
         
         addSubview(contentView)
         contentView.snp.makeConstraints {
-            $0.top.equalTo(topBar.snp.bottom).offset(10)
+            $0.top.equalTo(topBarArea.snp.bottom)
             $0.centerX.equalToSuperview()
             $0.width.equalToSuperview().multipliedBy(0.9)
             $0.height.equalToSuperview().multipliedBy(0.83)

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -60,7 +60,7 @@ final class BottomSheet: UIControl {
         //recognizer이 끝났을 때 상태 업데이트
         guard recognizer.state == .ended else { return }
         let isDownward = recognizer.velocity(in: self).y > 0
-        let yPosition: CGFloat = updatedY > maxTopOffset*0.7 ? maxTopOffset : updatedY
+        let yPosition: CGFloat = updatedY > maxTopOffset*0.8 ? maxTopOffset : minTopOffset
 
         if isDownward {
             updateConstraints(yPosition)
@@ -70,7 +70,9 @@ final class BottomSheet: UIControl {
         
         if yPosition >= maxTopOffset {
             closeFlag = true
-        }        
+        }
+        
+        UIView.animate(withDuration: 0.4, delay: .zero, animations: layoutIfNeeded)
     }
     
     private func setupViews() {

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -60,13 +60,9 @@ final class BottomSheet: UIControl {
         //recognizer이 끝났을 때 상태 업데이트
         guard recognizer.state == .ended else { return }
         let isDownward = recognizer.velocity(in: self).y > 0
-        let yPosition: CGFloat = updatedY > maxTopOffset*0.8 ? maxTopOffset : minTopOffset
-
-        if isDownward {
-            updateConstraints(yPosition)
-        } else {
-            updateConstraints(minTopOffset)
-        }
+        let yPosition: CGFloat = isDownward ? (updatedY > maxTopOffset*0.8 ? maxTopOffset : minTopOffset) : minTopOffset
+        
+        updateConstraints(yPosition)
         
         if yPosition >= maxTopOffset {
             closeFlag = true

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SnapKit
 
-final class BottomSheet: UIView {
+final class BottomSheet: UIControl {
     
     private let topBar: UIView = {
         let view = UIView()
@@ -11,6 +11,9 @@ final class BottomSheet: UIView {
     }()
     
     let contentView = UIView()
+    private var closeFlag = false {
+        didSet { sendActions(for: .valueChanged) }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -46,15 +46,19 @@ final class BottomSheet: UIControl {
 
 extension BottomSheet {
     
-    func move(upTo topConstraint: CGFloat,
+    private func updateConstraints(_ topOffset: CGFloat) {
+        self.snp.remakeConstraints {
+            $0.left.right.bottom.equalToSuperview()
+            $0.top.equalToSuperview().inset(topOffset)
+        }
+    }
+    
+    func move(upTo topOffset: CGFloat,
               duration: CGFloat,
               animation: @escaping () -> Void,
               completion: @escaping (Bool) -> Void = { _ in }) {
         
-        self.snp.remakeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(topConstraint)
-        }
+        updateConstraints(topOffset)
         
         UIView.animate(
             withDuration: duration,

--- a/rabit/rabit/Goal/Models/CertifiableTime.swift
+++ b/rabit/rabit/Goal/Models/CertifiableTime.swift
@@ -16,8 +16,8 @@ struct CertifiableTime: CustomStringConvertible {
         let start = currDate.toTimeComponent()
         let end = Calendar.current.date(byAdding: .hour, value: 5, to: currDate)?.toTimeComponent() ?? start
        
-        self.start = start
-        self.end =  end
+        self.start = TimeComponent(hour: 9)
+        self.end =  TimeComponent(hour: 21)
         self.days = Days()
     }
     

--- a/rabit/rabit/Goal/Models/TimeComponent.swift
+++ b/rabit/rabit/Goal/Models/TimeComponent.swift
@@ -13,7 +13,7 @@ struct TimeComponent: Equatable {
         return "\(ampm) \(hour)시 \(minute)분"
     }
     
-    init(hour: Int, minute: Int, seconds: Int) {
+    init(hour: Int, minute: Int = .zero, seconds: Int = .zero) {
         self.hour = hour
         self.minute = minute
         self.seconds = seconds

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -87,14 +87,10 @@ final class TimeSelectViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        timeSelectSheet.rx.swipeGesture(.down)
-            .when(.ended)
-            .withUnretained(self)
-            .bind { viewController, _ in
-                viewController.hideTimeSelectSheet()
-            }
+        timeSelectSheet.rx.isClosed
+            .bind(onNext: hideTimeSelectSheet)
             .disposed(by: disposeBag)
-        
+
         timeRangeSlider.rx.leftValue
             .distinctUntilChanged()
             .bind(to: viewModel.selectedStartTime)
@@ -186,7 +182,7 @@ final class TimeSelectViewController: UIViewController {
         view.addSubview(timeSelectSheet)
         timeSelectSheet.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(view.snp.bottom)
+            $0.top.equalTo(view.bounds.height)
         }
         
         timeSelectSheet.contentView.addSubview(titleLabel)
@@ -249,7 +245,6 @@ private extension TimeSelectViewController {
     func showTimeSelectSheet() {
         
         dimmedView.isHidden = false
-        isModalInPresentation = true
         
         timeSelectSheet.move(
             upTo: view.bounds.height*0.65,
@@ -260,9 +255,7 @@ private extension TimeSelectViewController {
     
     func hideTimeSelectSheet() {
         guard let viewModel = viewModel else { return }
-        
-        isModalInPresentation = false
-        
+    
         timeSelectSheet.move(
             upTo: view.bounds.height,
             duration: 0.2,

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -20,8 +20,8 @@ final class TimeSelectViewController: UIViewController {
         return view
     }()
     
-    private let timeSelectSheet: BottomSheet = {
-        let sheet = BottomSheet()
+    private lazy var timeSelectSheet: BottomSheet = {
+        let sheet = BottomSheet(view.bounds.height, view.bounds.height*0.65)
         sheet.backgroundColor = .white
         sheet.roundCorners(20)
         return sheet

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -212,7 +212,7 @@ final class TimeSelectViewController: UIViewController {
         
         timeSelectSheet.contentView.addSubview(saveButton)
         saveButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(10)
+            $0.top.equalTo(timeRangeSlider.snp.bottom).offset(10)
             $0.centerX.equalToSuperview()
         }
     }

--- a/rabit/rabit/Goal/TimeSelect/Views/DaySelectCell.swift
+++ b/rabit/rabit/Goal/TimeSelect/Views/DaySelectCell.swift
@@ -23,9 +23,14 @@ final class DaySelectCell: UICollectionViewCell {
         }
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        nameLabel.roundCorners(self.bounds.height/2)
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-
+        
         setupViews()
     }
 

--- a/rabit/rabit/Utilities/BottomSheet + Reactive.swift
+++ b/rabit/rabit/Utilities/BottomSheet + Reactive.swift
@@ -1,0 +1,10 @@
+import Foundation
+import RxSwift
+import RxCocoa
+
+extension Reactive where Base: BottomSheet {
+    
+    var isClosed: ControlEvent<Void> {
+        base.rx.controlEvent(.valueChanged)
+    }
+}


### PR DESCRIPTION
## 💡 작업내용
- 기존에는 RxGesture을 적용해서 단순히 위에서 아래로 swipe하는 경우에 자동으로 BottomSheet이 내려가도록 구현
- 자연스러운 동작이 아니라 판단해서 BottomSheet을 위에서 아래로 swipe할 때, 사용자의 터치 입력에 따라 BottomSheet이 움직이도록 다시 구현
- 위에서 아래로 터치됨에 따라 BottomSheet의 y값을 변화시키고, y값이 일정 수준 이하로 내려가면 화면을 닫도록 구현

## 💡 실행 화면

![Simulator Screen Recording - iPhone 12 mini - 2022-09-29 at 23 09 01](https://user-images.githubusercontent.com/68586291/193054359-6d2d5f03-a967-481f-bfdf-6d4be44144eb.gif)

