### PR TITLE
BottomSheet의 contentView 레이아웃 수정 및 오류 해결

### DIFF
--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -36,11 +36,6 @@ final class BottomSheet: UIControl {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        let hitView = super.hitTest(point, with: event)
-        return hitView == self ? nil : hitView
-    }
-    
     private func addPanGestureRecognizer() {
         let recognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))
         topBarArea.addGestureRecognizer(recognizer)
@@ -89,7 +84,8 @@ final class BottomSheet: UIControl {
         addSubview(contentView)
         contentView.snp.makeConstraints {
             $0.top.equalTo(topBarArea.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(1)
         }
     }
 }

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -14,14 +14,16 @@ final class BottomSheet: UIControl {
     let contentView = UIView()
     private var minTopOffset: CGFloat = .zero
     private var maxTopOffset: CGFloat = .zero
+    private var defaultHeight: CGFloat = .zero
     private var closeFlag = false {
         didSet { if closeFlag { sendActions(for: .valueChanged) } }
     }
     
-    convenience init(_ maxTopOffset: CGFloat, _ minTopOffset: CGFloat) {
+    convenience init(_ superViewHeight: CGFloat, _ bottomSheetHeight: CGFloat) {
         self.init()
-        self.maxTopOffset = maxTopOffset
-        self.minTopOffset = minTopOffset
+        self.maxTopOffset = superViewHeight
+        self.minTopOffset = superViewHeight - bottomSheetHeight
+        self.defaultHeight = bottomSheetHeight
         setupViews()
         addPanGestureRecognizer()
     }
@@ -42,6 +44,7 @@ final class BottomSheet: UIControl {
     }
     
     @objc private func didPan(_ recognizer: UIPanGestureRecognizer) {
+        
         //이동된 y 거리 계산
         let updatedY = frame.minY + recognizer.translation(in: self).y
         
@@ -85,7 +88,7 @@ final class BottomSheet: UIControl {
         contentView.snp.makeConstraints {
             $0.top.equalTo(topBarArea.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(1)
+            $0.bottom.equalToSuperview()
         }
     }
 }
@@ -94,8 +97,9 @@ extension BottomSheet {
     
     private func updateConstraints(_ topOffset: CGFloat) {
         self.snp.remakeConstraints {
-            $0.left.right.bottom.equalToSuperview()
-            $0.top.equalToSuperview().inset(topOffset)
+            $0.top.equalToSuperview().offset(topOffset)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(defaultHeight)
         }
     }
     

--- a/rabit/rabit/Common/Views/BottomSheet.swift
+++ b/rabit/rabit/Common/Views/BottomSheet.swift
@@ -89,9 +89,7 @@ final class BottomSheet: UIControl {
         addSubview(contentView)
         contentView.snp.makeConstraints {
             $0.top.equalTo(topBarArea.snp.bottom)
-            $0.centerX.equalToSuperview()
-            $0.width.equalToSuperview().multipliedBy(0.9)
-            $0.height.equalToSuperview().multipliedBy(0.83)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
 }

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -20,8 +20,9 @@ final class TimeSelectViewController: UIViewController {
         return view
     }()
     
+    private lazy var timeSelectSheetHeight = view.bounds.height*0.36
     private lazy var timeSelectSheet: BottomSheet = {
-        let sheet = BottomSheet(view.bounds.height, view.bounds.height*0.65)
+        let sheet = BottomSheet(view.bounds.height, timeSelectSheetHeight)
         sheet.backgroundColor = .white
         sheet.roundCorners(20)
         return sheet
@@ -181,8 +182,10 @@ final class TimeSelectViewController: UIViewController {
         
         view.addSubview(timeSelectSheet)
         timeSelectSheet.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(view.bounds.height)
+            $0.top.equalToSuperview().offset(view.frame.height)
+            $0.height.equalTo(timeSelectSheetHeight)
+            $0.leading.trailing.equalToSuperview()
+            
         }
         
         timeSelectSheet.contentView.addSubview(titleLabel)
@@ -194,12 +197,12 @@ final class TimeSelectViewController: UIViewController {
         daySelectCollectionView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalToSuperview().multipliedBy(0.2)
+            $0.height.equalToSuperview().multipliedBy(0.17)
         }
 
         timeSelectSheet.contentView.addSubview(timePreviewLabel)
         timePreviewLabel.snp.makeConstraints {
-            $0.top.equalTo(daySelectCollectionView.snp.bottom).offset(5)
+            $0.top.equalTo(daySelectCollectionView.snp.bottom).offset(10)
             $0.leading.equalToSuperview().offset(20)
         }
         
@@ -207,12 +210,12 @@ final class TimeSelectViewController: UIViewController {
         timeRangeSlider.snp.makeConstraints {
             $0.top.equalTo(timePreviewLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalToSuperview().multipliedBy(0.1)
+            $0.height.equalToSuperview().multipliedBy(0.08)
         }
         
         timeSelectSheet.contentView.addSubview(saveButton)
         saveButton.snp.makeConstraints {
-            $0.top.equalTo(timeRangeSlider.snp.bottom).offset(10)
+            $0.top.equalTo(timeRangeSlider.snp.bottom).offset(15)
             $0.centerX.equalToSuperview()
         }
     }
@@ -247,7 +250,7 @@ private extension TimeSelectViewController {
         dimmedView.isHidden = false
         
         timeSelectSheet.move(
-            upTo: view.bounds.height*0.65,
+            upTo: view.bounds.height - timeSelectSheetHeight,
             duration: 0.2,
             animation: self.view.layoutIfNeeded
         )

--- a/rabit/rabit/Goal/TimeSelect/Views/DaySelectCell.swift
+++ b/rabit/rabit/Goal/TimeSelect/Views/DaySelectCell.swift
@@ -22,12 +22,7 @@ final class DaySelectCell: UICollectionViewCell {
             checkMarkImageView.isHidden = !isSelected
         }
     }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        nameLabel.roundCorners(self.bounds.height/2)
-    }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         


### PR DESCRIPTION
close #62 #55 

주말에 PR 올린다는게 게으름 피우다가 이제서야 올려요 ㅜㅠㅠ 🙏
높이를 동적으로 변화시키는 방식으로 BottomSheet을 구현하다보니까, 이것 때문에 사소하게 오류가 너무 많이 나서 레이아웃 방식을 아얘 바꿔버렸어요!(중간중간 뜯어고치느라 시간이 좀 걸렸습니다..)

## 작업내용
- [x] contentView 영역 BottomSheet 꽉 채우도록 수정
- [x] 기존에 BottomSheet의 높이를 동적으로 변화시킴에 따라 발생하던 레이아웃 깨지는 문제 수정

## 수정사항
기존에는 BottomSheet을 아래로 이동시킬 때마다 아래와 같은 방식으로 애니메이션을 처리했습니다.
- leading,trailing,bottom 세 가지 요소는 모두 고정시킴
- top의 offset을 변화시키면서 결과적으로 BottomSheet의 높이를 동적으로 변화시킴

```swift
    private func updateConstraints(_ topOffset: CGFloat) {
        self.snp.remakeConstraints {
            $0.left.right.bottom.equalToSuperview()
            $0.top.equalToSuperview().inset(topOffset)
        }
    }
```

위와 같은 방식으로 진행할 경우 기존에 내용 공유한대로 BottomSheet이 올라갔다, 내려갔다 하는 애니메이션이 구현되지만, 높이가 변함에 따라 __서브뷰들의 높이 및 다른 레이아웃 요소도 이에 영향을 받는다는 문제가 있었습니다.__

또한, 맨 처음에 BottomSheet을 숨김처리 하기 위해서 leading, trailing, bottom 세 가지 요소를 고정시킨 상태에서, top을 superView의 bottom과 맞춰서 결과적으로 높이가 0이 되도록 처리했는데, 이로 인해 레이아웃이 지속적으로 깨지는 문제가 발생했습니다.(#55 이슈 참고)
```swift
  timeSelectSheet.snp.makeConstraints {
      //leading, trailing, bottom은 슈퍼뷰와 동일하게 맞춰줌
      $0.leading.trailing.bottom.equalToSuperview()
      //맨 처음 top의 offset값을 슈퍼뷰의 height와 동일하게 맞춤으로써 사실상 슈퍼뷰의 bottom과 맞춰줌
      $0.top.equalTo(view.bounds.height)
  }
```

따라서 애초에 BottomSheet의 높이를 동적으로 변하는 방식으로 애니메이션을 처리하지 않고, 높이는 고정시키되 top을 계속해서 변화시키는 방식으로 BottomSheet이 올라갔다 내려갔다 하는 동작을 구현시키는 방식으로 처리했습니다.
```swift
    private func updateConstraints(_ topOffset: CGFloat) {
        self.snp.remakeConstraints {
            // 나머지 레이아웃 요소가 고정된 상태에서 top의 offset값만 변화시켜줌
            $0.top.equalToSuperview().offset(topOffset)
            $0.leading.trailing.equalToSuperview()
            // 높이는 맨 처음 정해준 값을 그대로 고정시킴
            $0.height.equalTo(defaultHeight)
        }
    }
```

 