### PR TITLE
UIImage(data:) 사용하는 스레드 수정작업 진행

### DIFF
--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -56,11 +56,13 @@ final class StyleSelectCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
-        DispatchQueue.global().sync {
-            let image = UIImage(data: photo.imageData)?.overlayText(of: photo)
+        let serialQueue = DispatchQueue(label: "Serial_Queue")
+
+        serialQueue.async {
+            let image = UIImage(data: photo.imageData)
 
             DispatchQueue.main.async {
-                self.previewImageView.image = image
+                self.previewImageView.image = image?.overlayText(of: photo)
                 self.nameLabel.text = photo.style.rawValue
             }
         }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -24,11 +24,13 @@ final class AlbumCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
-        DispatchQueue.global().sync {
-            let image = UIImage(data: photo.imageData)?.overlayText(of: photo)
+        let serialQueue = DispatchQueue(label: "Serial_Queue")
+
+        serialQueue.async {
+            let image = UIImage(data: photo.imageData)
 
             DispatchQueue.main.async {
-                self.thumbnailPictureView.image = image
+                self.thumbnailPictureView.image = image?.overlayText(of: photo)
             }
         }
     }


### PR DESCRIPTION
close #73 

## 진행 내용
- `UIImage(data: photo.imageData)`를 처리하는 스레드를 바꾸고자 아래의 코드를 작성했었습니다.
    
```swift
func configure(with photo: Photo) {
    DispatchQueue.global().sync {
        let image = UIImage(data: photo.imageData)?.overlayText(of: photo)

        DispatchQueue.main.async {
            self.thumbnailPictureView.image = image
        }
}
 ```
    `UIImage(data: photo.imageData)` 코드를 메인스레드에서 처리하면 오버헤드가 크다는 의견이 있었기 때문입니다.
- 하지만 코드를 바꿨음에도 메모리 사용량에는 큰 변화가 없었고, 해당 코드가 어느 스레드에서 실행되는지 확인해봤는데 그대로 메인 스레드에서 실행중임을 확인했습니다.
    
    ![SS2022-10-13PM04 37 20](https://user-images.githubusercontent.com/92504186/195557281-9c5757fe-37ea-4cb1-9878-3bf7c903826c.jpg)
    
- `DispatchQueue.global().sync`를 사용하면 해당 클로저를 호출하는 스레드를 block 시켜놓고 클로저를 실행하게 되므로, 글로벌 큐로 작업을 보냈지만 실질적으로는 메인 큐에서 하는 것과 다름이 없기 때문이라고 판단했습니다.
    
    원래, **순차적**으로 동작하도록 하기 위해 sync를 썼는데 sync vs serial가 헷갈려 이런 코드를 작성했었습니다....
    
- 개선을 위해 아래의 코드를 작성했지만 이번엔 UI작업을 메인 스레드에서 처리하지 않는다는 에러를 받게 됐습니다.
    
    ```swift
    func configure(with photo: Photo) {
    	let serialQueue = DispatchQueue(label: "Serial-Queue")
    	serialQueue.async {
    		let image = UIImage(data: photo.imageData)?.overlayText(of: photo)
    
    		DispatchQueue.main.async {
    			self.thumbnailPictureView.image = image
    		}
    }
    ```
    
    그 이유는 `overlayText(of:)`메소드에서 UILabel을 사용하고 있기 때문이라고 판단했습니다.
    
    - overlayText(of:) 코드 확인
        
        ```swift
        extension UIImage {
            func overlayText(of photo: Photo) -> UIImage? {
                let text = DateConverter.convertToDateString(date: photo.date)
                let textColor = UIColor(hexRGB: photo.color) ?? .white
                let fontSize: CGFloat = 100
                let imageSize = size
                let textFont = UIFont(name: photo.style.name, size: fontSize) ?? UIFont.systemFont(ofSize: 100)
        
                let attributedString = NSMutableAttributedString(string: text)
                attributedString.addAttributes(
                    [NSAttributedString.Key.font: textFont,
                     NSAttributedString.Key.foregroundColor: textColor],
                    range: (text as NSString).range(of: text)
                )
        
                let image = UIImage(data: photo.imageData) ?? UIImage()
        
                UIGraphicsBeginImageContextWithOptions(imageSize, false, 1.0)
        
                image.draw(in: CGRect(origin: .zero, size: imageSize))
                
                let label = UILabel()
                label.numberOfLines = 0
                label.textAlignment = .center
                label.attributedText = attributedString
                label.drawText(in: CGRect(origin: .zero, size: imageSize))
        
                let newImage = UIGraphicsGetImageFromCurrentImageContext()
                UIGraphicsEndImageContext()
                return newImage
            }
        }
        ```
        
    
    따라서 아래와 같이 코드를 수정했고, 그 결과 `UIImage(data:)` 코드는 메인스레드가 아닌 다른 스레드에서 실행되고, 메모리 사용량도 작게나마 줄어듦을 확인할 수 있었습니다.
    
    ```swift
    func configure(with photo: Album.Item) {
        let serialQueue = DispatchQueue(label: "Serial_Queue")
    
        serialQueue.async {
            let image = UIImage(data: photo.imageData)
    
            DispatchQueue.main.async {
                self.thumbnailPictureView.image = image?.overlayText(of: photo)
            }
        }
    }
    ```
    
    ![SS2022-10-13PM04 46 51](https://user-images.githubusercontent.com/92504186/195557321-3e89e934-ea40-4bd7-8236-ad5a6145f876.jpg)