### PR TITLE
CalendarView에 변경된 BottomSheet 적용

### DIFF
--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
@@ -12,8 +12,9 @@ final class PeriodSelectViewController: UIViewController {
         return view
     }()
     
-    private lazy var periodSheet: BottomSheet = {
-        let sheet = BottomSheet(view.bounds.height, view.bounds.height * 0.4)
+    private lazy var periodSelectSheetHeight = view.bounds.height * 0.5
+    private lazy var periodSelectSheet: BottomSheet = {
+        let sheet = BottomSheet(view.bounds.height, periodSelectSheetHeight)
         sheet.backgroundColor = .white
         sheet.roundCorners(20)
         return sheet
@@ -85,7 +86,7 @@ final class PeriodSelectViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        periodSheet.rx.isClosed
+        periodSelectSheet.rx.isClosed
             .bind(onNext: hidePeriodSheet)
             .disposed(by: disposeBag)
         
@@ -132,26 +133,28 @@ final class PeriodSelectViewController: UIViewController {
     private func setupViews() {
         
         view.addSubview(dimmedView)
-        dimmedView.snp.makeConstraints {
-            $0.top.bottom.leading.trailing.equalToSuperview()
+        dimmedView.snp.makeConstraints { make in
+            make.top.bottom.leading.trailing.equalToSuperview()
         }
         
-        view.addSubview(periodSheet)
-        periodSheet.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(view.snp.bottom)
+        view.addSubview(periodSelectSheet)
+        periodSelectSheet.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(view.bounds.height)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(periodSelectSheetHeight)
         }
         
-        periodSheet.contentView.addSubview(calendarCollectionView)
+        periodSelectSheet.contentView.addSubview(calendarCollectionView)
         calendarCollectionView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-            make.height.equalToSuperview().multipliedBy(0.9)
+            make.top.leading.equalToSuperview().offset(20)
+            make.trailing.equalToSuperview().inset(20)
+            make.height.equalToSuperview().multipliedBy(0.75)
         }
         
-        periodSheet.contentView.addSubview(saveButton)
-        saveButton.snp.makeConstraints {
-            $0.top.equalTo(calendarCollectionView.snp.bottom).offset(15)
-            $0.centerX.equalToSuperview()
+        periodSelectSheet.contentView.addSubview(saveButton)
+        saveButton.snp.makeConstraints { make in
+            make.top.equalTo(calendarCollectionView.snp.bottom).offset(15)
+            make.centerX.equalToSuperview()
         }
     }
 }
@@ -174,10 +177,9 @@ private extension PeriodSelectViewController {
     func showPeriodSheet() {
         
         dimmedView.isHidden = false
-        isModalInPresentation = true
 
-        periodSheet.move(
-            upTo: view.bounds.height*0.4,
+        periodSelectSheet.move(
+            upTo: view.bounds.height - periodSelectSheetHeight,
             duration: 0.2,
             animation: self.view.layoutIfNeeded
         )
@@ -188,7 +190,7 @@ private extension PeriodSelectViewController {
         
         isModalInPresentation = false
         
-        periodSheet.move(
+        periodSelectSheet.move(
             upTo: view.bounds.height,
             duration: 0.2,
             animation: view.layoutIfNeeded


### PR DESCRIPTION
close #75 
- 이전에 CalendarView에 변경된 BottomSheet을 적용했다고 생각했는데 미처 적용하지 못 한 부분이 있어 마저 적용했습니다.

### 진행 내역
- [x] 여러 군데에서 사용할 `periodSelectSheetHeight` 프로퍼티 추가
- [x] 기존에 적용되어 있던 `periodSelectSheet`의 Bottom Constraint 제거
- [x] BottomSheet.contentView의 좌우 여백이 제거됨에 따라 calendarCollectionView의 좌우 여백 추가