### PR TITLE
Retain-Cycle 제거를 위한 리팩토링 진행

### DIFF
--- a/rabit/rabit/Album/AlbumViewController.swift
+++ b/rabit/rabit/Album/AlbumViewController.swift
@@ -4,7 +4,7 @@ import RxSwift
 import RxCocoa
 import RxDataSources
 
-typealias DataSource = CollectionViewSectionedDataSource<Album>
+typealias AlbumDataSource = RxCollectionViewSectionedReloadDataSource<Album>
 
 final class AlbumViewController: UIViewController {
     private let albumCollectionView: UICollectionView = {
@@ -15,10 +15,9 @@ final class AlbumViewController: UIViewController {
         return collectionView
     }()
 
+    private lazy var dataSource: AlbumDataSource = initializeDataSource()
+
     private var disposeBag = DisposeBag()
-    private lazy var dataSource: RxCollectionViewSectionedReloadDataSource<Album> = {
-        return initializeDataSource()
-    }()
 
     private var viewModel: AlbumViewModelProtocol?
 
@@ -84,41 +83,33 @@ private extension AlbumViewController {
         )
     }
 
-    func initializeDataSource() -> RxCollectionViewSectionedReloadDataSource<Album> {
-        let configureCell: (DataSource, UICollectionView, IndexPath, Album.Item) -> UICollectionViewCell = { dataSource, collectionView, indexPath, item in
-            guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: AlbumCell.identifier,
-                for: indexPath) as? AlbumCell else { return UICollectionViewCell(
-            ) }
+    func initializeDataSource() -> AlbumDataSource {
+        return AlbumDataSource(
+            configureCell: { dataSource, collectionView, indexPath, item in
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: AlbumCell.identifier,
+                    for: indexPath) as? AlbumCell else { return UICollectionViewCell(
+                ) }
 
-            let itemData = dataSource.sectionModels[indexPath.section].items[indexPath.item]
+                let itemData = dataSource.sectionModels[indexPath.section].items[indexPath.item]
 
-            cell.configure(with: itemData)
-            return cell
-        }
+                cell.configure(with: itemData)
+                return cell
+            },
+            configureSupplementaryView: { (dataSource, collectionView, kind, indexPath) in
+                guard kind == UICollectionView.elementKindSectionHeader,
+                      let header = collectionView.dequeueReusableSupplementaryView(
+                          ofKind: kind,
+                          withReuseIdentifier: AlbumHeaderView.identifier,
+                          for: indexPath
+                      ) as? AlbumHeaderView else {
+                    return UICollectionReusableView()
+                }
+                let headerTitle = dataSource.sectionModels[indexPath.section].categoryTitle
+                header.configure(with: headerTitle)
 
-        let configureHeaderView: (DataSource, UICollectionView, String, IndexPath) -> UICollectionReusableView = { (dataSource, collectionView, kind, indexPath) in
-            guard kind == UICollectionView.elementKindSectionHeader,
-                  let header = collectionView.dequeueReusableSupplementaryView(
-                      ofKind: kind,
-                      withReuseIdentifier: AlbumHeaderView.identifier,
-                      for: indexPath
-                  ) as? AlbumHeaderView else {
-                return UICollectionReusableView()
-            }
-
-            let headerTitle = dataSource.sectionModels[indexPath.section].categoryTitle
-            header.configure(with: headerTitle)
-
-            return header
-        }
-
-        let dataSource = RxCollectionViewSectionedReloadDataSource<Album>(
-            configureCell: configureCell,
-            configureSupplementaryView: configureHeaderView
-        )
-
-        return dataSource
+                return header
+            })
     }
 
     func bind() {

--- a/rabit/rabit/Album/StyleSelect/StyleSelectViewController.swift
+++ b/rabit/rabit/Album/StyleSelect/StyleSelectViewController.swift
@@ -129,8 +129,14 @@ private extension StyleSelectViewController {
             .disposed(by: disposeBag)
 
         styleSelectCollectionView.rx.itemSelected
-            .map { ($0, UICollectionView.ScrollPosition.centeredHorizontally, true) }
-            .bind(onNext: styleSelectCollectionView.scrollToItem(at:at:animated:))
+            .withUnretained(self.styleSelectCollectionView)
+            .bind { collectionView, selectedIndexPath in
+                collectionView.scrollToItem(
+                    at: selectedIndexPath,
+                    at: .centeredHorizontally,
+                    animated: true
+                )
+            }
             .disposed(by: disposeBag)
 
         dimmedView.rx.tapGesture()
@@ -142,7 +148,10 @@ private extension StyleSelectViewController {
             .disposed(by: disposeBag)
 
         styleSheet.rx.isClosed
-            .bind(onNext: hideStyleSheet)
+            .withUnretained(self)
+            .bind { viewController, _ in
+                viewController.hideStyleSheet()
+            }
             .disposed(by: disposeBag)
 
         saveButton.rx.tap

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
@@ -3,8 +3,9 @@ import SnapKit
 import RxSwift
 import RxDataSources
 
+typealias CalendarDataSource = RxCollectionViewSectionedReloadDataSource<CalendarDates>
+
 final class PeriodSelectViewController: UIViewController {
-    typealias CalendarDataSource = RxCollectionViewSectionedReloadDataSource<CalendarDates>
     
     private let dimmedView: UIView = {
         let view = UIView()
@@ -202,8 +203,8 @@ private extension PeriodSelectViewController {
         }
     }
 
-    func initializeDataSource() -> RxCollectionViewSectionedReloadDataSource<CalendarDates> {
-        return RxCollectionViewSectionedReloadDataSource<CalendarDates>(
+    func initializeDataSource() -> CalendarDataSource {
+        return CalendarDataSource(
             configureCell: { [weak self] dataSource, collectionView, indexPath, item in
                 guard let periodData = self?.viewModel?.selectedPeriod.value,
                       let cell = collectionView.dequeueReusableCell(

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
@@ -86,8 +86,11 @@ final class PeriodSelectViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        periodSelectSheet.rx.isClosed
-            .bind(onNext: hidePeriodSheet)
+        periodSheet.rx.isClosed
+            .withUnretained(self)
+            .bind { viewController, _ in
+                viewController.hidePeriodSheet()
+            }
             .disposed(by: disposeBag)
         
         viewModel.calendarData
@@ -96,10 +99,10 @@ final class PeriodSelectViewController: UIViewController {
 
         saveButton.rx.tap
             .withUnretained(self)
-            .bind(onNext: { viewController, _ in
+            .bind { viewController, _ in
                 viewModel.saveButtonTouched.accept(())
                 viewController.hidePeriodSheet()
-            })
+            }
             .disposed(by: disposeBag)
 
         viewModel.saveButtonState

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -89,7 +89,10 @@ final class TimeSelectViewController: UIViewController {
             .disposed(by: disposeBag)
         
         timeSelectSheet.rx.isClosed
-            .bind(onNext: hideTimeSelectSheet)
+            .withUnretained(self)
+            .bind { viewController, _ in
+                viewController.hideTimeSelectSheet()
+            }
             .disposed(by: disposeBag)
 
         timeRangeSlider.rx.leftValue


### PR DESCRIPTION
- 여러 ViewController들에서 `Observable.bind(onNext:)`를 사용할 때에 ViewController의 메소드, 프로퍼티 등을 참조하는 경우가 있어, 해당 부분에서 Retain-Cycle이 발생했습니다.
  - `withUnretained(_:)` 오퍼레이터를 활용하여 self에 대한 참조를 제거하는 방향으로 리팩토링했습니다.

- 또한, PeriodSelectViewController의 경우, DataSource로 인한 Retain-Cycle이 발생했음을 확인했습니다.
  - 해당 이슈의 경우, DataSource를 초기화해주는 메소드에서 VC 내부의 메소드들을 호출하는 코드가 존재하여 PeriodSelectViewController와 DataSource간 순환 참조가 발생했음을 확인하여, VC 내부 메소드를 DataSource 초기화해주는 메소드 내의 클로저로 변경하여 순환 참조를 방지하여 리팩토링했습니다.