### PR TITLE
CertPhotoCameraViewController 리팩토링

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		B5E3052528E7F4A40044B592 /* InsertField + Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E3052428E7F4A40044B592 /* InsertField + Reactive.swift */; };
 		B5E64D6128FD0B33009B2191 /* CertPhotoCameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E64D6028FD0B33009B2191 /* CertPhotoCameraViewModel.swift */; };
 		B5F37E6C28E5DA92007FF5E5 /* BottomSheet + Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */; };
+		B5FDE17128FFD30100B51B88 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FDE17028FFD30100B51B88 /* CameraManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -213,6 +214,7 @@
 		B5E3052428E7F4A40044B592 /* InsertField + Reactive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsertField + Reactive.swift"; sourceTree = "<group>"; };
 		B5E64D6028FD0B33009B2191 /* CertPhotoCameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertPhotoCameraViewModel.swift; sourceTree = "<group>"; };
 		B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BottomSheet + Reactive.swift"; sourceTree = "<group>"; };
+		B5FDE17028FFD30100B51B88 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -414,6 +416,7 @@
 				B52AEB2A28F7340100923A86 /* Views */,
 				B52AEB2728F5C24E00923A86 /* CertPhotoCameraViewController.swift */,
 				B5E64D6028FD0B33009B2191 /* CertPhotoCameraViewModel.swift */,
+				B5FDE17028FFD30100B51B88 /* CameraManager.swift */,
 			);
 			path = CertPhotoCamera;
 			sourceTree = "<group>";
@@ -783,6 +786,7 @@
 				B5B9413C28AF6DE60098022F /* GoalAddViewController.swift in Sources */,
 				B56AF75228C6528B001C82C0 /* RangeSlider + Reactive.swift in Sources */,
 				02D30E7128C878EC00B5C4B2 /* CalendarDates.swift in Sources */,
+				B5FDE17128FFD30100B51B88 /* CameraManager.swift in Sources */,
 				B563D9BE28BA5A3C00A755EB /* Period.swift in Sources */,
 				B58A1C2328B5F9AF00D5783F /* RealmManager.swift in Sources */,
 				027EA68128EC82380097E802 /* Style.swift in Sources */,
@@ -835,7 +839,6 @@
 				02972D5D28B61E76008C097D /* Persistable.swift in Sources */,
 				B5D131E2289C2A1B00EE1833 /* GoalProgressView.swift in Sources */,
 				B5D131D6289A0D6B00EE1833 /* GoalCoordinator.swift in Sources */,
-				0232BD9528AE11DD009057F8 /* ColorSelectViewModel.swift in Sources */,
 				B5E64D6128FD0B33009B2191 /* CertPhotoCameraViewModel.swift in Sources */,
 				B5F37E6C28E5DA92007FF5E5 /* BottomSheet + Reactive.swift in Sources */,
 				02F37254289E1EA200F361C7 /* PaddingLabel.swift in Sources */,

--- a/rabit/rabit/Goal/CertPhotoCamera/CameraManager.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CameraManager.swift
@@ -1,0 +1,87 @@
+import AVFoundation
+import UIKit
+
+final class CameraManager: NSObject {
+    
+    private let capturingSessinoQueue = DispatchQueue(label: "CapturingSessionQueue", qos: .background)
+    private let capturingSession: AVCaptureSession = AVCaptureSession()
+    private var capturingInput: AVCaptureDeviceInput?
+    private let capturingOutput = AVCapturePhotoOutput()
+    private lazy var previewLayer = AVCaptureVideoPreviewLayer(session: capturingSession)
+
+    private var completionHandler: ((Data) -> Void)?
+    
+    func prepareCapturing(with previewLayerView: UIView) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.setPreviewLayer(with: previewLayerView)
+            
+            self.capturingSessinoQueue.async {
+                self.setupCapturingSession()
+                self.capturingSession.startRunning()
+            }
+        }
+    }
+    
+    func capture(completionHandler: @escaping (Data) -> Void) {
+        capturingOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
+        self.completionHandler = completionHandler
+    }
+    
+    func endCapturing() {
+        capturingSession.stopRunning()
+    }
+
+    deinit {
+        if capturingSession.isRunning {
+           endCapturing()
+        }
+    }
+}
+
+extension CameraManager: AVCapturePhotoCaptureDelegate {
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        if let originalImageData = photo.fileDataRepresentation() {
+            completionHandler?(originalImageData)
+        }
+    }
+}
+
+private extension CameraManager {
+    
+    //device input setup
+    func setupInputDevice() {
+        guard let device = AVCaptureDevice.default(for: .video) else { return }
+        let input = try? AVCaptureDeviceInput(device: device)
+        self.capturingInput = input
+    }
+    
+    //session configuration
+    func setupCapturingSession() {
+        capturingSession.beginConfiguration()
+        setupInputDevice()
+        guard let capturingInput = capturingInput else { return }
+        
+        capturingSession.sessionPreset = .photo
+        if capturingSession.canAddInput(capturingInput) {
+            capturingSession.addInput(capturingInput)
+        }
+        
+        if capturingSession.canAddOutput(capturingOutput) {
+            capturingSession.addOutput(capturingOutput)
+        }
+        
+        previewLayer.connection?.videoOrientation = .portrait
+        
+        capturingSession.commitConfiguration()
+    }
+    
+    //preview layer setup
+    func setPreviewLayer(with previewLayerView: UIView) {
+        previewLayer.frame = previewLayerView.bounds
+        previewLayerView.layer.addSublayer(previewLayer)
+        previewLayer.videoGravity = .resizeAspectFill
+    }
+}
+

--- a/rabit/rabit/Goal/CertPhotoCamera/CameraManager.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CameraManager.swift
@@ -1,7 +1,14 @@
 import AVFoundation
 import UIKit
 
-final class CameraManager {
+protocol CameraManagable {
+    
+    func prepareCapturing(with previewLayerView: UIView)
+    func capture(completionHandler: @escaping (Data) -> Void)
+    func endCapturing()
+}
+
+final class CameraManager: CameraManagable {
     
     private let capturingSessinoQueue = DispatchQueue(label: "CapturingSessionQueue", qos: .background)
     private let capturingSession: AVCaptureSession = AVCaptureSession()

--- a/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
@@ -46,7 +46,6 @@ final class CertPhotoCameraViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        captureSession?.stopRunning()
         tabBarController?.tabBar.isHidden = false
     }
     

--- a/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
@@ -26,7 +26,7 @@ final class CertPhotoCameraViewController: UIViewController {
     
     private let shutterButton: UIButton = {
         let button = UIButton()
-        button.layer.borderColor = UIColor.white.cgColor
+        button.layer.borderColor = UIColor.systemGray.cgColor
         button.layer.cornerRadius = 50
         button.layer.borderWidth = 10
         return button
@@ -34,7 +34,7 @@ final class CertPhotoCameraViewController: UIViewController {
     
     private let nextButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .white
+        button.backgroundColor = .systemGray
         button.layer.cornerRadius = 50
         button.setTitle("✅", for: .normal)
         button.setTitleColor(.black, for: .normal)
@@ -158,7 +158,7 @@ final class CertPhotoCameraViewController: UIViewController {
     
     private func setAttributes() {
         
-        view.backgroundColor = .black
+        view.backgroundColor = .white
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: nil)
     }
     

--- a/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
@@ -10,20 +10,6 @@ final class CertPhotoCameraViewController: UIViewController {
     private let capturedOutput = AVCapturePhotoOutput()
     private let previewLayer = AVCaptureVideoPreviewLayer()
     
-    private lazy var dimmedView: DimmedView = {
-        let totalWidth = view.bounds.width
-        let totalHeight = view.bounds.height
-        let length = min(totalWidth, totalHeight)
-        
-        let centerOrigin = CGPoint(x: .zero, y: (totalHeight-length)/2)
-        let centerSize = CGSize(width: length, height: length)
-        let centerRect = CGRect(origin: centerOrigin, size: centerSize)
-        
-        let backgroundColor = UIColor.black.withAlphaComponent(0.8)
-        let view = DimmedView(backgroundColor: backgroundColor, transparentRect: centerRect)
-        return view
-    }()
-    
     private let shutterButton: UIButton = {
         let button = UIButton()
         button.layer.borderColor = UIColor.systemGray.cgColor
@@ -124,18 +110,15 @@ final class CertPhotoCameraViewController: UIViewController {
         
         view.addSubview(previewLayerView)
         previewLayerView.snp.makeConstraints {
-            $0.centerY.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview().offset(120)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(view.snp.width)
-        }
-        
-        view.addSubview(dimmedView)
-        dimmedView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
         }
         
         view.addSubview(previewImageView)
         previewImageView.snp.makeConstraints {
-            $0.centerY.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview().offset(100)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(previewLayerView.snp.width)
         }
         
@@ -144,7 +127,7 @@ final class CertPhotoCameraViewController: UIViewController {
             $0.width.equalTo(100)
             $0.height.equalTo(100)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(30)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(100)
         }
         
         view.addSubview(nextButton)
@@ -152,7 +135,7 @@ final class CertPhotoCameraViewController: UIViewController {
             $0.width.equalTo(100)
             $0.height.equalTo(100)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(30)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(100)
         }
     }
     

--- a/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewController.swift
@@ -31,7 +31,7 @@ final class CertPhotoCameraViewController: UIViewController {
     }()
     
     private let disposeBag = DisposeBag()
-    private let cameraManager = CameraManager()
+    private let cameraManager: CameraManagable = CameraManager()
     private var viewModel: CertPhotoCameraViewModel?
     
     convenience init(viewModel: CertPhotoCameraViewModel) {


### PR DESCRIPTION
- [x] AVFoundation에 의존하는 로직 모두 별도의 클래스로 이동
- [x] bind() 메소드 외부에서 뷰모델의 input 속성에 접근하는 부분 모두 제거