### PR TITLE
이미지 리사이징을 통한 메모리 사용량 개선

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		025CA12628A631C0007AAADE /* AlbumRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA12528A631C0007AAADE /* AlbumRepository.swift */; };
 		027EA68128EC82380097E802 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EA68028EC82380097E802 /* Style.swift */; };
 		027EA68328EC8D720097E802 /* StyleSelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EA68228EC8D720097E802 /* StyleSelectCell.swift */; };
+		028A409329023B8300349F48 /* Data + Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028A409229023B8300349F48 /* Data + Utils.swift */; };
 		02972D5D28B61E76008C097D /* Persistable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02972D5C28B61E76008C097D /* Persistable.swift */; };
 		02972D5F28B74343008C097D /* PhotoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02972D5E28B74342008C097D /* PhotoEntity.swift */; };
 		02A093C828B8A52B00BDF69B /* CategoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A093C728B8A52B00BDF69B /* CategoryEntity.swift */; };
@@ -138,6 +139,7 @@
 		025CA12528A631C0007AAADE /* AlbumRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumRepository.swift; sourceTree = "<group>"; };
 		027EA68028EC82380097E802 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		027EA68228EC8D720097E802 /* StyleSelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleSelectCell.swift; sourceTree = "<group>"; };
+		028A409229023B8300349F48 /* Data + Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data + Utils.swift"; sourceTree = "<group>"; };
 		02972D5C28B61E76008C097D /* Persistable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistable.swift; sourceTree = "<group>"; };
 		02972D5E28B74342008C097D /* PhotoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoEntity.swift; sourceTree = "<group>"; };
 		02A093C728B8A52B00BDF69B /* CategoryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEntity.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 				B5F37E6B28E5DA92007FF5E5 /* BottomSheet + Reactive.swift */,
 				B5E3052428E7F4A40044B592 /* InsertField + Reactive.swift */,
 				B5CC800928ED79B2009665F8 /* Date + Strideable.swift */,
+				028A409229023B8300349F48 /* Data + Utils.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -795,6 +798,7 @@
 				B582574828BF3330001AE268 /* TimeComponent.swift in Sources */,
 				02D30E6B28C8689000B5C4B2 /* CalendarCell.swift in Sources */,
 				0252098F289A661E00E7E604 /* AlbumHeaderView.swift in Sources */,
+				028A409329023B8300349F48 /* Data + Utils.swift in Sources */,
 				02DABAAC28EC4516001416DC /* StyleSelectViewModel.swift in Sources */,
 				02520987289A5A2400E7E604 /* AlbumViewController.swift in Sources */,
 				02F37251289CE21400F361C7 /* Album.swift in Sources */,

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -111,8 +111,12 @@ private extension PhotoEditViewController {
         let updatedPhotoImage = viewModel.selectedPhotoData
             .map(\.imageData)
             .compactMap {
-                $0.toDownsampledImage(pointSize: imageSize)
+                $0.toDownsampledCGImage(
+                    pointSize: imageSize,
+                    scale: UIScreen.main.scale
+                )
             }
+            .compactMap(UIImage.init)
             .withLatestFrom(viewModel.selectedPhotoData) {
                 $0.overlayText(of: $1)
             }

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -102,9 +102,16 @@ private extension PhotoEditViewController {
     func bind() {
         guard let viewModel = viewModel else { return }
 
+        let imageSize = CGSize(
+            width: view.bounds.width,
+            height: view.bounds.width
+        )
+
         let updatedPhotoImage = viewModel.selectedPhotoData
             .map(\.imageData)
-            .compactMap(UIImage.init(data:))
+            .compactMap {
+                $0.toDownsampledImage(pointSize: imageSize)
+            }
             .withLatestFrom(viewModel.selectedPhotoData) {
                 $0.overlayText(of: $1)
             }

--- a/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/Album/PhotoEdit/PhotoEditViewController.swift
@@ -102,9 +102,10 @@ private extension PhotoEditViewController {
     func bind() {
         guard let viewModel = viewModel else { return }
 
+        let imageLength = view.bounds.width
         let imageSize = CGSize(
-            width: view.bounds.width,
-            height: view.bounds.width
+            width: imageLength,
+            height: imageLength
         )
 
         let updatedPhotoImage = viewModel.selectedPhotoData

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -56,15 +56,14 @@ final class StyleSelectCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
-        let serialQueue = DispatchQueue(label: "Serial_Queue")
 
         let imageSize = CGSize(
             width: bounds.width,
             height: bounds.width
         )
 
-        serialQueue.async {
             let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+        DispatchQueue.global().async {
 
             DispatchQueue.main.async {
                 self.previewImageView.image = image?.overlayText(of: photo)

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -62,8 +62,8 @@ final class StyleSelectCell: UICollectionViewCell {
             height: bounds.width
         )
 
-            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
         DispatchQueue.global().async {
+            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
 
             DispatchQueue.main.async {
                 self.previewImageView.image = image?.overlayText(of: photo)

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -58,11 +58,17 @@ final class StyleSelectCell: UICollectionViewCell {
     func configure(with photo: Album.Item) {
         let serialQueue = DispatchQueue(label: "Serial_Queue")
 
+        let imageSize = CGSize(
+            width: bounds.width,
+            height: bounds.width
+        )
+
         serialQueue.async {
-            let image = UIImage(data: photo.imageData)
+            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+            let scale = (image?.size.width ?? 0) / imageSize.width
 
             DispatchQueue.main.async {
-                self.previewImageView.image = image?.overlayText(of: photo)
+                self.previewImageView.image = image?.overlayText(of: photo, scale: scale)
                 self.nameLabel.text = photo.style.rawValue
             }
         }

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -65,10 +65,9 @@ final class StyleSelectCell: UICollectionViewCell {
 
         serialQueue.async {
             let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
-            let scale = (image?.size.width ?? 0) / imageSize.width
 
             DispatchQueue.main.async {
-                self.previewImageView.image = image?.overlayText(of: photo, scale: scale)
+                self.previewImageView.image = image?.overlayText(of: photo)
                 self.nameLabel.text = photo.style.rawValue
             }
         }

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -62,11 +62,13 @@ final class StyleSelectCell: UICollectionViewCell {
             height: bounds.width
         )
 
-        DispatchQueue.global().async {
-            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+        DispatchQueue.global(qos: .userInteractive).async {
+            guard let downsampledCGImage = photo.imageData
+                .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
+            let image = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                self.previewImageView.image = image?.overlayText(of: photo)
+                self.previewImageView.image = image.overlayText(of: photo)
                 self.nameLabel.text = photo.style.rawValue
             }
         }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -30,8 +30,8 @@ final class AlbumCell: UICollectionViewCell {
             height: bounds.width - 20
         )
 
-            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
         DispatchQueue.global().async {
+            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
 
             DispatchQueue.main.async {
                 self.thumbnailPictureView.image = image?.overlayText(of: photo)

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -30,11 +30,13 @@ final class AlbumCell: UICollectionViewCell {
             height: bounds.width - 20
         )
 
-        DispatchQueue.global().async {
-            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+        DispatchQueue.global(qos: .userInteractive).async {
+            guard let downsampledCGImage = photo.imageData
+                .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
+            let image = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                self.thumbnailPictureView.image = image?.overlayText(of: photo)
+                self.thumbnailPictureView.image = image.overlayText(of: photo)
             }
         }
     }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -24,15 +24,14 @@ final class AlbumCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
-        let serialQueue = DispatchQueue(label: "Serial_Queue")
 
         let imageSize = CGSize(
             width: bounds.width - 20,
             height: bounds.width - 20
         )
 
-        serialQueue.async {
             let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+        DispatchQueue.global().async {
 
             DispatchQueue.main.async {
                 self.thumbnailPictureView.image = image?.overlayText(of: photo)

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -26,11 +26,17 @@ final class AlbumCell: UICollectionViewCell {
     func configure(with photo: Album.Item) {
         let serialQueue = DispatchQueue(label: "Serial_Queue")
 
+        let imageSize = CGSize(
+            width: bounds.width - 20,
+            height: bounds.width - 20
+        )
+
         serialQueue.async {
-            let image = UIImage(data: photo.imageData)
+            let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
+            let scale = (image?.size.width ?? 0) / imageSize.width
 
             DispatchQueue.main.async {
-                self.thumbnailPictureView.image = image?.overlayText(of: photo)
+                self.thumbnailPictureView.image = image?.overlayText(of: photo, scale: scale)
             }
         }
     }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -33,10 +33,9 @@ final class AlbumCell: UICollectionViewCell {
 
         serialQueue.async {
             let image = photo.imageData.toDownsampledImage(pointSize: imageSize, scale: 2.0)
-            let scale = (image?.size.width ?? 0) / imageSize.width
 
             DispatchQueue.main.async {
-                self.thumbnailPictureView.image = image?.overlayText(of: photo, scale: scale)
+                self.thumbnailPictureView.image = image?.overlayText(of: photo)
             }
         }
     }

--- a/rabit/rabit/Utilities/Data + Utils.swift
+++ b/rabit/rabit/Utilities/Data + Utils.swift
@@ -1,7 +1,8 @@
-import UIKit
+import Foundation
+import ImageIO
 
 extension Data {
-    func toDownsampledImage(pointSize: CGSize, scale: CGFloat = UIScreen.main.scale) -> UIImage? {
+    func toDownsampledCGImage(pointSize: CGSize, scale: CGFloat) -> CGImage? {
         let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let imageSource = CGImageSourceCreateWithData(
             self as CFData,
@@ -16,14 +17,6 @@ extension Data {
             kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
         ] as CFDictionary
 
-        if let downsampledImage = CGImageSourceCreateThumbnailAtIndex(
-            imageSource,
-            0,
-            downsampleOptions
-        ) {
-            return UIImage(cgImage: downsampledImage)
-        }
-
-        return nil
+        return CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions)
     }
 }

--- a/rabit/rabit/Utilities/Data + Utils.swift
+++ b/rabit/rabit/Utilities/Data + Utils.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+extension Data {
+    func toDownsampledImage(pointSize: CGSize, scale: CGFloat = UIScreen.main.scale) -> UIImage? {
+        let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let imageSource = CGImageSourceCreateWithData(
+            self as CFData,
+            imageSourceOptions) else {
+            return nil
+        }
+        let maxDimensionInPixels = Swift.max(pointSize.width, pointSize.height) * scale
+        let downsampleOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
+        ] as CFDictionary
+
+        if let downsampledImage = CGImageSourceCreateThumbnailAtIndex(
+            imageSource,
+            0,
+            downsampleOptions
+        ) {
+            return UIImage(cgImage: downsampledImage)
+        }
+
+        return nil
+    }
+}

--- a/rabit/rabit/Utilities/UIImage + Utils.swift
+++ b/rabit/rabit/Utilities/UIImage + Utils.swift
@@ -37,13 +37,13 @@ extension UIImage {
         return UIImage(cgImage: croppedImage, scale: 1.0, orientation: self.imageOrientation)
     }
     
-    func overlayText(of photo: Photo) -> UIImage? {
+    func overlayText(of photo: Photo, scale: CGFloat = UIScreen.main.scale) -> UIImage? {
         let text = DateConverter.convertToDateString(date: photo.date)
-        let textColor = UIColor(hexRGB: photo.color) ?? .white
-        let fontSize: CGFloat = 100
-        let imageSize = size
-        let textFont = UIFont(name: photo.style.name, size: fontSize) ?? UIFont.systemFont(ofSize: 100)
-        
+        let textColor = UIColor(hexRGB: photo.color) ?? .clear
+        let fontSize: CGFloat = 0.1 * size.height
+        let imageSize = CGSize(width: size.width/scale, height: size.height/scale)
+        let textFont = UIFont(name: photo.style.name, size: fontSize) ?? .systemFont(ofSize: 0.1 * size.height)
+
         let attributedString = NSMutableAttributedString(string: text)
         attributedString.addAttributes(
             [NSAttributedString.Key.font: textFont,

--- a/rabit/rabit/Utilities/UIImage + Utils.swift
+++ b/rabit/rabit/Utilities/UIImage + Utils.swift
@@ -37,11 +37,11 @@ extension UIImage {
         return UIImage(cgImage: croppedImage, scale: 1.0, orientation: self.imageOrientation)
     }
     
-    func overlayText(of photo: Photo, scale: CGFloat = UIScreen.main.scale) -> UIImage? {
+    func overlayText(of photo: Photo) -> UIImage? {
         let text = DateConverter.convertToDateString(date: photo.date)
         let textColor = UIColor(hexRGB: photo.color) ?? .clear
         let fontSize: CGFloat = 0.1 * size.height
-        let imageSize = CGSize(width: size.width/scale, height: size.height/scale)
+        let imageSize = CGSize(width: size.width, height: size.height)
         let textFont = UIFont(name: photo.style.name, size: fontSize) ?? .systemFont(ofSize: 0.1 * size.height)
 
         let attributedString = NSMutableAttributedString(string: text)


### PR DESCRIPTION
close #79 

- [x] Image Resizing을 통한 메모리 사용량 개선

(트러블 슈팅 내용을 일단 여기에 정리해놓겠습니다!)

### 이미지와 메모리 최적화에 대한 고민

* 기존에는 아래와 같은 로직으로 UIImageView에 이미지를 넣었습니다.

```swift
func configure(with photo: Photo) {
    let image = UIImage(data: photo.imageData)

    thumbnailImageView.image = image
}
```

하지만 `Data` 타입을 이용해 UIImage를 렌더링하는 초기화 생성자가 스레드에 상당한 부담을 준다는 사실을 확인(여러 이미지를 보여주는 AlbumView에서 사용 메모리가 120MB 까지 올라가는 현상이 있었음)하여, 다른 스레드를 사용해 메인스레드에서의 부담을 줄여주어 메모리 부담을 개선할 수 있었습니다.

```swift
func configure(with photo: Photo) {
    let serialQueue = DispatchQueue(label: "Serial_Queue")

    serialQueue.async {
        let image = UIImage(data: photo.imageData)

        DispatchQueue.main.async {
            thumbnailImageView.image = image
        }
    }
}
```



* 하지만 추후 이미지에 Text를 얹어 보여주는 기능을 추가함에 따라 메모리 부담이 다시 늘어나는 문제가 있었습니다. 이미지에 Text를 얹어 보여주는 기능은 아래의 메소드를 사용했습니다.

```swift
extension UIImage {
    func overlayText(of photoData: Photo) -> UIImage? {
        let text = DateConverter.convertToDateString(date: photo.date)
        let textColor = UIColor(hexRGB: photo.color) ?? .clear
        let fontSize: CGFloat = 0.1 * self.size.height
        let imageSize = CGSize(width: size.width, height: size.height)
        let textFont = UIFont(name: photo.style.name, size: fontSize) ?? UIFont(name: Style.none.rawValue, size: fontSize) ?? .systemFont(ofSize: 0)

        let attributedString = NSMutableAttributedString(string: text)
        attributedString.addAttributes(
             [NSAttributedString.Key.font: textFont,
                NSAttributedString.Key.foregroundColor: textColor],
            range: (text as NSString).range(of: text)
        )
    
        UIGraphicBeginImageContextWithOptions(imageSize, false, 1.0)
        self.draw(in: CGRect(origin: .zero, size: imageSize)

        let label = UILabel()
        label.numberOfLines = 0
        label.textAlginment = .center
        label.attributedText = attributedString
        label.drawText(in: CGRect(origin: .zero, size: imageSize))

        let newImage = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()

        return newImage
}
```

해당 메소드에서 UILabel을 사용하고 있기 때문에 SerialQueue로 해당 작업을 보낼 수 없어 MainQueue에서 작업을 진행하도록 했는데, UILabel을 사용하지 않고 `NSString.draw(in:)`메소드를 사용할 수 있어 해당 방법을 사용했으나 메모리 사용량에 개선이 많지 않았습니다.

```swift
extension UIImage {
    func overlayText(of photoData: Photo) -> UIImage? {
        let text = DateConverter.convertToDateString(date: photo.date)
        let textColor = UIColor(hexRGB: photo.color) ?? .clear
        let fontSize: CGFloat = 0.1 * self.size.height
        let imageSize = CGSize(width: size.width, height: size.height)
        let textFont = UIFont(name: photo.style.name, size: fontSize) ?? UIFont(name: Style.none.rawValue, size: fontSize) ?? .systemFont(ofSize: 0)
        let paragraph = NSMutableParagraphStyle()
        paragraph.alignment = .center

        let attributedString = NSMutableAttributedString(string: text)
        attributedString.addAttributes(
             [NSAttributedString.Key.font: textFont,
                NSAttributedString.Key.foregroundColor: textColor,
                NSAttributedString.Key.paragraphStyle: paragraph]
            range: (text as NSString).range(of: text)
        )
    
        UIGraphicBeginImageContextWithOptions(imageSize, false, 1.0)
        self.draw(in: CGRect(origin: .zero, size: imageSize)

        attributedString.draw(in: CGRect(origin: .zero, size: imageSize)) // <--

        let newImage = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()

        return newImage
}
```

따라서 추후 Photo.Style을 현재 사용하고 있는 글씨체(UIFont) 변경의 기능에서 여러 모양을 가지는 UIView를 추가할 예정이고, 메모리 사용량 개선에 큰 의미없는 부분 때문에 억지로 SerialQueue에서 처리 가능하도록 할 필요가 없다고 생각하여, UILabel을 사용하는 코드로 계속 사용하도록 했습니다.

* 또한 위의 코드에서 이미지를 렌더링하는 때에 사용한 `UIGraphicsBeginImageContextWithOptions`의 경우 SRGB format의 색영역 사용을 강제한다는 문제가 있어, 메모리 개선을 위해 iOS 10부터 사용할 수 있는 `UIGraphicsImageRenderer`를 사용해 컴파일러가 적절한 색영역 사용을 선택할 수 있도록 하여 메모리 사용을 개선할 수 있다고 판단해 아래의 코드를 사용해보았습니다.

```swift
extension UIImage {
    func overlayText(of photoData: Photo) -> UIImage? {
        let text = DateConverter.convertToDateString(date: photo.date)
        let textColor = UIColor(hexRGB: photo.color) ?? .clear
        let fontSize: CGFloat = 0.1 * self.size.height
        let imageSize = CGSize(width: size.width, height: size.height)
        let textFont = UIFont(name: photo.style.name, size: fontSize) ?? UIFont(name: Style.none.rawValue, size: fontSize) ?? .systemFont(ofSize: 0)
        let paragraph = NSMutableParagraphStyle()
        paragraph.alignment = .center

        let attributedString = NSMutableAttributedString(string: text)
        attributedString.addAttributes(
             [NSAttributedString.Key.font: textFont,
                NSAttributedString.Key.foregroundColor: textColor,
                NSAttributedString.Key.paragraphStyle: paragraph],
            range: (text as NSString).range(of: text)
    )
    
        let renderer = UIGraphicsImageRenderer(size: imageSize)
        return renderer.image { context in
                self.draw(in: CGRect(origin: .zero, size: imageSize))

                let label = UILabel()
                label.numberOfLines = 0
                label.textAlignment = .center
                label.attributedText = attributedString
                label.drawText(in: CGRect(origin: .zero, size: imageSize))
    }
}
```

하지만, 여러 색이 들어있는 UIImage도 렌더링하기 때문에 sRGB 색영역을 사용할텐데 컴파일러가 사용할 색 영역을 선택하는 과정에서의 메모리 부하가 발생하여 기존보다 메모리 사용량이 크게 늘어나는 문제가 발생한다고 판단하여 해당 코드도 사용하지 않도록 했습니다.

| `UIGraphicsBeginImageContextWithOptions` 사용시              | `UIGraphicsImageRenderer` 사용시                             |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| ![SS2022-10-20PM09.54.41](https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202210202210713.jpg) | ![SS2022-10-20PM10.08.07](https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202210202210834.jpg) |



* 마지막으로 생각한 개선의 여지는 UIImage를 만들 때 `UIImage(data:)` 초기화 생성자가 아닌, Data에 있는 이미지 정보를 CGImage 단계에서 적절한 크기의 이미지로 Downsampling 한 후에 UIImage에 그려주는 방법입니다. 이미지를 Downsampling 해주는 코드는 아래의 코드를 사용했습니다.

```swift
extension Data {
    func toDownsampledImage(pointSize: CGSize, scale: CGFloat) -> UIImage? {
        let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
        guard let imageSource = CGImageSourceCreateWithData(self as CFData, imageSourceOptions) else {
            return nil
        }
        let maxDimensionInPixels = Swift.max(pointSize.width, pointSize.height) * scale
        let downsampleOptions = [
            kCGImageSourceCreateThumbnailFromImageAlways: true,
            kCGImageSourceShouldCacheImmediately: true,
            kCGImageSourceCreateThumbnailWithTransform: true,
            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
        ] as CFDictionary

        if let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) {
            return UIImage(cgImage: downsampledImage)
        }

        return nil
    }
}
```

1. `kCGImageSourceCreateThumbnailFromImageAlways`

    - 원본 이미지 소스 파일에 Thumbnail이 있는지, 원본 이미지에서 Thumbnail을 새로 만들어야하는지를 설정하는 옵션입니다.

    - 해당 값을 true로 설정하면 `kCGImageSourceThumbnailMaxPixelSize`에 지정된 제한에 따라 full image로부터 Thumbnail을 만들고, `kCGImageSourceThumbnailMaxPixelSize`를 지정하지 않으면 최대 원본 이미지 크기만큼의 Thumbnail을 만듭니다.

2. `kCGImageSourceShouldCacheImmediately`

    * Thumbnail 생성을 요청 하는 시점에 Core Graphics에게 이미지 디코딩을 시작하라는 알림을 주는 옵션입니다.
    * false로 설정할 경우(default), 이미지 데이터 객체를 생성할 뿐이니 이미지 소스에 대한 참조만 생성하고, 곧바로 이미지 디코딩을 시작하지 말라는 의미의 옵션입니다.

3. `kCGImageSourceThumbnailMaxPixelSize`

    * Thumbnail의 최대 픽셀을 지정하는 옵션입니다.

4. `kCGImageSourceCreateThumbnailWithTransform`

    - 원본 이미지의 방향 및 종횡비에 따라 Thumbnail을 회전 및 스케일링해야하는지를 설정하는 옵션입니다.

    - 해당 옵션을 true로 설정함으로써 Core Graphics에게 원본 이미지와 Downsampling된 이미지의 orientation이 같도록 설정할 수 있습니다.

위의 코드를 사용한 Downsampling으로 이미지로 인한 메모리 사용량을 개선할 수 있었습니다. 또한 Downsampling된 이미지를 사용할 경우 메모리가 순간적으로 큰 값으로 튀는 구간도 어느정도 제어할 수 있었기 때문에 그로 인한 개선도 할 수 있었습니다.

| Downsampling 이전                                            | Downsampling 이후                                            |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| ![SS2022-10-20PM09.54.41](https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202210202201675.jpg) | ![SS2022-10-20PM09.48.39](https://raw.githubusercontent.com/Hansolkkim/Image-Upload/forUpload/img/202210202252556.jpg) |
