### PR TITLE
컬렉션 뷰 성능 개선

### DIFF
--- a/rabit/rabit.xcodeproj/project.pbxproj
+++ b/rabit/rabit.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		02972D5F28B74343008C097D /* PhotoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02972D5E28B74342008C097D /* PhotoEntity.swift */; };
 		02A093C828B8A52B00BDF69B /* CategoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A093C728B8A52B00BDF69B /* CategoryEntity.swift */; };
 		02A093CA28B8A67800BDF69B /* GoalEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A093C928B8A67800BDF69B /* GoalEntity.swift */; };
+		02A385012906804C00B57660 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A385002906804C00B57660 /* ImageCacheManager.swift */; };
 		02B7FD26289A1E3400EBA86D /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 02B7FD25289A1E3400EBA86D /* SnapKit */; };
 		02B7FD29289A1EC300EBA86D /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 02B7FD28289A1EC300EBA86D /* RealmSwift */; };
 		02B7FD2C289A1EEC00EBA86D /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 02B7FD2B289A1EEC00EBA86D /* RxCocoa */; };
@@ -144,6 +145,7 @@
 		02972D5E28B74342008C097D /* PhotoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoEntity.swift; sourceTree = "<group>"; };
 		02A093C728B8A52B00BDF69B /* CategoryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEntity.swift; sourceTree = "<group>"; };
 		02A093C928B8A67800BDF69B /* GoalEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEntity.swift; sourceTree = "<group>"; };
+		02A385002906804C00B57660 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		02B916DA28B89ADF0086F29E /* RealmResults + toArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealmResults + toArray.swift"; sourceTree = "<group>"; };
 		02C9713428AF82390087B8D2 /* UIImage + Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage + Utils.swift"; sourceTree = "<group>"; };
 		02C9713628B356200087B8D2 /* ColorSelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectCell.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				B5D131CC289A04E600EE1833 /* Coordinator */,
 				B58A1C2228B5F9AF00D5783F /* RealmManager.swift */,
 				02972D5C28B61E76008C097D /* Persistable.swift */,
+				02A385002906804C00B57660 /* ImageCacheManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -807,6 +810,7 @@
 				B52AEB2828F5C24E00923A86 /* CertPhotoCameraViewController.swift in Sources */,
 				B59BB3C928A8354B007C5013 /* CategoryAddViewModel.swift in Sources */,
 				02D30E7728C87EBF00B5C4B2 /* CalendarDate.swift in Sources */,
+				02A385012906804C00B57660 /* ImageCacheManager.swift in Sources */,
 				02DABAA928EC44F2001416DC /* StyleSelectViewController.swift in Sources */,
 				B5D131DF289C178A00EE1833 /* GoalListCollectionViewCell.swift in Sources */,
 				02D30E6D28C86AB100B5C4B2 /* String + strikeThrough.swift in Sources */,

--- a/rabit/rabit/Album/AlbumViewController.swift
+++ b/rabit/rabit/Album/AlbumViewController.swift
@@ -160,20 +160,21 @@ private extension AlbumViewController {
 
         let prefetchTarget = viewModel.albumData.value[indexPath.section].items[indexPath.item]
         let cacheKey = "\(prefetchTarget.uuid)\(prefetchTarget.style)\(prefetchTarget.color)\(AlbumCell.identifier)" as NSString
+
+        guard ImageCacheManager.shared.object(forKey: cacheKey) == nil else { return }
+
         let imageSize = CGSize(
             width: view.bounds.width - 20,
             height: view.bounds.width - 20
         )
 
-        guard ImageCacheManager.shared.object(forKey: cacheKey) == nil else { return }
-
         DispatchQueue.global().async {
             guard let downsampledCGImage = prefetchTarget.imageData
                 .toDownsampledCGImage(pointSize: imageSize, scale: 0.5) else { return }
-            let image = UIImage(cgImage: downsampledCGImage)
+            let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                let textOverlayedImage = image.overlayText(of: prefetchTarget) ?? UIImage()
+                let textOverlayedImage = downsampledUIImage.overlayText(of: prefetchTarget) ?? UIImage()
                 ImageCacheManager.shared.setObject(textOverlayedImage, forKey: cacheKey)
             }
         }

--- a/rabit/rabit/Album/AlbumViewController.swift
+++ b/rabit/rabit/Album/AlbumViewController.swift
@@ -103,8 +103,7 @@ private extension AlbumViewController {
         viewModel.albumData
             .map { albumArray in
                 albumArray
-                    .map { ($0, $0.items) }
-                    .map(AlbumSectionType.init(model:items:))
+                    .map { AlbumSectionType(model: $0, items: $0.items) }
             }
             .bind(to: albumCollectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)

--- a/rabit/rabit/Album/Models/Album.swift
+++ b/rabit/rabit/Album/Models/Album.swift
@@ -12,9 +12,15 @@ struct Album {
     }
 }
 
-extension Album: SectionModelType {
+extension Album: AnimatableSectionModelType {
+    typealias Identity = String
+
     init(original: Album, items: [Item]) {
         self = original
         self.items = items
+    }
+
+    var identity: String {
+        return self.categoryTitle
     }
 }

--- a/rabit/rabit/Album/Models/Photo.swift
+++ b/rabit/rabit/Album/Models/Photo.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Differentiator
 
 struct Photo: Equatable {
     let uuid: UUID
@@ -36,6 +37,14 @@ struct Photo: Equatable {
             color: "",
             style: .none
         )
+    }
+}
+
+extension Photo: IdentifiableType {
+    typealias identifier = UUID
+
+    var identity: UUID {
+        return self.uuid
     }
 }
 

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -71,10 +71,10 @@ final class StyleSelectCell: UICollectionViewCell {
         DispatchQueue.global(qos: .userInteractive).async {
             guard let downsampledCGImage = photo.imageData
                 .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
-            let image = UIImage(cgImage: downsampledCGImage)
+            let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                if let image = image.overlayText(of: photo) {
+                if let image = downsampledUIImage.overlayText(of: photo) {
                     ImageCacheManager.shared.setObject(image, forKey: cacheKey)
                     self.previewImageView.image = image
                 }

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -56,6 +56,12 @@ final class StyleSelectCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
+        let cacheKey = "\(photo.uuid)\(photo.style)\(photo.color)\(self)" as NSString
+
+        if let cachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
+            self.previewImageView.image = cachedImage
+            return
+        }
 
         let imageSize = CGSize(
             width: bounds.width,
@@ -68,7 +74,10 @@ final class StyleSelectCell: UICollectionViewCell {
             let image = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                self.previewImageView.image = image.overlayText(of: photo)
+                if let image = image.overlayText(of: photo) {
+                    ImageCacheManager.shared.setObject(image, forKey: cacheKey)
+                    self.previewImageView.image = image
+                }
                 self.nameLabel.text = photo.style.rawValue
             }
         }

--- a/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/Album/StyleSelect/Views/StyleSelectCell.swift
@@ -56,7 +56,7 @@ final class StyleSelectCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
-        let cacheKey = "\(photo.uuid)\(photo.style)\(photo.color)\(self)" as NSString
+        let cacheKey = "\(photo.uuid)\(photo.style)\(photo.color)\(Self.identifier)" as NSString
 
         if let cachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
             self.previewImageView.image = cachedImage

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -24,6 +24,12 @@ final class AlbumCell: UICollectionViewCell {
     }
 
     func configure(with photo: Album.Item) {
+        let cacheKey = "\(photo.uuid)\(photo.style)\(photo.color)\(Self.identifier)" as NSString
+
+        if let chachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
+            self.thumbnailPictureView.image = chachedImage
+            return
+        }
 
         let imageSize = CGSize(
             width: bounds.width - 20,
@@ -36,7 +42,10 @@ final class AlbumCell: UICollectionViewCell {
             let image = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                self.thumbnailPictureView.image = image.overlayText(of: photo)
+                if let image = image.overlayText(of: photo) {
+                    ImageCacheManager.shared.setObject(image, forKey: cacheKey)
+                    self.thumbnailPictureView.image = image
+                }
             }
         }
     }

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -39,10 +39,10 @@ final class AlbumCell: UICollectionViewCell {
         DispatchQueue.global(qos: .userInteractive).async {
             guard let downsampledCGImage = photo.imageData
                 .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
-            let image = UIImage(cgImage: downsampledCGImage)
+            let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
-                if let image = image.overlayText(of: photo) {
+                if let image = downsampledUIImage.overlayText(of: photo) {
                     ImageCacheManager.shared.setObject(image, forKey: cacheKey)
                     self.thumbnailPictureView.image = image
                 }

--- a/rabit/rabit/Common/ImageCacheManager.swift
+++ b/rabit/rabit/Common/ImageCacheManager.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class ImageCacheManager {
+    static let shared = NSCache<NSString, UIImage>()
+
+    private init() { }
+}

--- a/rabit/rabit/Goal/Models/CalendarDate.swift
+++ b/rabit/rabit/Goal/Models/CalendarDate.swift
@@ -1,8 +1,17 @@
 import Foundation
+import Differentiator
 
-struct CalendarDate {
+struct CalendarDate: Equatable {
     let date: Date
     let number: String
     var isWithinDisplayedMonth: Bool
     var isBeforeToday: Bool
+}
+
+extension CalendarDate: IdentifiableType {
+    typealias identifier = Date
+
+    var identity: Date {
+        return self.date
+    }
 }

--- a/rabit/rabit/Goal/Models/CalendarDates.swift
+++ b/rabit/rabit/Goal/Models/CalendarDates.swift
@@ -3,16 +3,24 @@ import Differentiator
 
 struct CalendarDates {
     typealias Item = CalendarDate
+    var id: UUID
     var items: [Item]
 
     init(items: [Item]) {
+        self.id = UUID()
         self.items = items
     }
 }
 
-extension CalendarDates: SectionModelType {
+extension CalendarDates: AnimatableSectionModelType {
+    typealias identity = UUID
+
     init(original: CalendarDates, items: [Item]) {
         self = original
         self.items = items
+    }
+
+    var identity: UUID {
+        return self.id
     }
 }

--- a/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
+++ b/rabit/rabit/Goal/PeriodSelect/PeriodSelectViewController.swift
@@ -96,9 +96,7 @@ final class PeriodSelectViewController: UIViewController {
         
         viewModel.calendarData
             .map { dataArray in
-                dataArray
-                    .map { ($0, $0.items) }
-                    .map(CalendarSectionType.init(model:items:))
+                dataArray.map { CalendarSectionType(model: $0, items: $0.items) }
             }
             .bind(to: calendarCollectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)


### PR DESCRIPTION
- 이미지를 가지는 컬렉션 뷰의 성능을 3가지 측면에서 개선했습니다.
1. 메모리 캐싱을 이용하여 UIImageView에 들어갈 이미지 중 이미 캐시에 저장되어 있는 이미지는 메모리로부터 받아오도록 개선.
2. UICollectionViewDataSourcePrefetching 프로토콜의 `collectionView(_: UICollectionView, prefetchItemsAt: [IndexPath])` 메소드와 같은 방법인 `UICollectionView.rx.prefetchItems`를 활용하여 Prefetching 대상이 되는 Cell의 이미지를 미리 받아와 메모리 캐싱 처리해놓도록 개선
3. 변경된 Cell의 변경이 화면에 적용될 시 모든 Cell이 reload되는 것이 아니라, 해당하는 Cell만 reload 될 수 있도록 개선