### PR TITLE
카테고리 및 목표 리스트 정렬, Goal에 IdentifiableType 채택 적용

### DIFF
--- a/rabit/rabit/Goal/GoalListRepository.swift
+++ b/rabit/rabit/Goal/GoalListRepository.swift
@@ -24,7 +24,7 @@ private extension GoalListRepository {
         let categoryEntities = realmManager.read(entity: CategoryEntity.self)
         
         categoryEntities.forEach {
-            cateogryMap[$0.title] = Category(title: $0.title)
+            cateogryMap[$0.title] = Category(entity: $0)
         }
         
         goalEntities.forEach {
@@ -34,9 +34,14 @@ private extension GoalListRepository {
             goal.progress = photoCount
             cateogryMap[$0.category]?.items.append(goal)
         }
-
-        return cateogryMap.values.map { $0 }
+        
+        return cateogryMap.values
+                          .map { category in
+                              var category = category
+                              category.items.sort { $0.creationDate < $1.creationDate }
+                              return category
+                          }
+                          .sorted { $0.creationDate < $1.creationDate }
     }
-    
 }
 

--- a/rabit/rabit/Goal/GoalListRepository.swift
+++ b/rabit/rabit/Goal/GoalListRepository.swift
@@ -18,13 +18,14 @@ final class GoalListRepository {
 private extension GoalListRepository {
     
     func getLatestGoals() -> [Category] {
-        var cateogryMap: [String:Category] = [:]
+        var categoryMap: [String:Category] = [:]
 
         let goalEntities = realmManager.read(entity: GoalEntity.self)
+                                       .sorted { $0.creationDate < $1.creationDate }
         let categoryEntities = realmManager.read(entity: CategoryEntity.self)
         
         categoryEntities.forEach {
-            cateogryMap[$0.title] = Category(entity: $0)
+            categoryMap[$0.title] = Category(entity: $0)
         }
         
         goalEntities.forEach {
@@ -32,16 +33,10 @@ private extension GoalListRepository {
             let goalTitle = goal.title
             let photoCount = realmManager.read(entity: PhotoEntity.self, filter: "goalTitle == '\(goalTitle)'").count
             goal.progress = photoCount
-            cateogryMap[$0.category]?.items.append(goal)
+            categoryMap[$0.category]?.items.append(goal)
         }
         
-        return cateogryMap.values
-                          .map { category in
-                              var category = category
-                              category.items.sort { $0.creationDate < $1.creationDate }
-                              return category
-                          }
-                          .sorted { $0.creationDate < $1.creationDate }
+        return Array(categoryMap.values).sorted { $0.creationDate < $1.creationDate }
     }
 }
 

--- a/rabit/rabit/Goal/GoalListRepository.swift
+++ b/rabit/rabit/Goal/GoalListRepository.swift
@@ -21,7 +21,7 @@ private extension GoalListRepository {
         var categoryMap: [String:Category] = [:]
 
         let goalEntities = realmManager.read(entity: GoalEntity.self)
-                                       .sorted { $0.creationDate < $1.creationDate }
+                                       .sorted { $0.createdDate < $1.createdDate }
         let categoryEntities = realmManager.read(entity: CategoryEntity.self)
         
         categoryEntities.forEach {
@@ -36,7 +36,7 @@ private extension GoalListRepository {
             categoryMap[$0.category]?.items.append(goal)
         }
         
-        return Array(categoryMap.values).sorted { $0.creationDate < $1.creationDate }
+        return Array(categoryMap.values).sorted { $0.createdDate < $1.createdDate }
     }
 }
 

--- a/rabit/rabit/Goal/Models/Category.swift
+++ b/rabit/rabit/Goal/Models/Category.swift
@@ -14,11 +14,16 @@ struct Category {
     }
 }
 
-extension Category: SectionModelType {
+extension Category: AnimatableSectionModelType {
+    typealias Identity = String
     
     init(original: Category, items: [Goal]) {
         self = original
         self.items = items
+    }
+    
+    var identity: String {
+        return title
     }
 }
 

--- a/rabit/rabit/Goal/Models/Category.swift
+++ b/rabit/rabit/Goal/Models/Category.swift
@@ -5,12 +5,12 @@ struct Category {
     
     let title: String
     var items: [Goal]
-    let creationDate: Date
+    let createdDate: Date
     
-    init(title: String, details: [Goal] = [], creationDate: Date = Date()) {
+    init(title: String, details: [Goal] = [], createdDate: Date = Date()) {
         self.title = title
         self.items = details
-        self.creationDate = creationDate
+        self.createdDate = createdDate
     }
 }
 
@@ -31,11 +31,11 @@ extension Category: Persistable {
     
     init(entity: CategoryEntity) {
         self.title = entity.title
-        self.creationDate = entity.creationDate
+        self.createdDate = entity.createdDate
         self.items = []
     }
     
     func toEntity() -> CategoryEntity {
-        .init(title: title, creationDate: creationDate)
+        .init(title: title, createdDate: createdDate)
     }
 }

--- a/rabit/rabit/Goal/Models/Category.swift
+++ b/rabit/rabit/Goal/Models/Category.swift
@@ -5,10 +5,12 @@ struct Category {
     
     let title: String
     var items: [Goal]
+    let creationDate: Date
     
-    init(title: String, details: [Goal] = []) {
+    init(title: String, details: [Goal] = [], creationDate: Date = Date()) {
         self.title = title
         self.items = details
+        self.creationDate = creationDate
     }
 }
 
@@ -24,10 +26,11 @@ extension Category: Persistable {
     
     init(entity: CategoryEntity) {
         self.title = entity.title
+        self.creationDate = entity.creationDate
         self.items = []
     }
     
     func toEntity() -> CategoryEntity {
-        .init(title: title)
+        .init(title: title, creationDate: creationDate)
     }
 }

--- a/rabit/rabit/Goal/Models/CategoryEntity.swift
+++ b/rabit/rabit/Goal/Models/CategoryEntity.swift
@@ -1,13 +1,16 @@
+import Foundation
 import RealmSwift
 
 class CategoryEntity: Object {
     
     @Persisted var title: String = ""
+    @Persisted var creationDate: Date
 
-    convenience init(title: String) {
+    convenience init(title: String, creationDate: Date) {
         self.init()
 
         self.title = title
+        self.creationDate = creationDate
     }
     
     override static func primaryKey() -> String? {

--- a/rabit/rabit/Goal/Models/CategoryEntity.swift
+++ b/rabit/rabit/Goal/Models/CategoryEntity.swift
@@ -4,13 +4,13 @@ import RealmSwift
 class CategoryEntity: Object {
     
     @Persisted var title: String = ""
-    @Persisted var creationDate: Date
+    @Persisted var createdDate: Date
 
-    convenience init(title: String, creationDate: Date) {
+    convenience init(title: String, createdDate: Date) {
         self.init()
 
         self.title = title
-        self.creationDate = creationDate
+        self.createdDate = createdDate
     }
     
     override static func primaryKey() -> String? {

--- a/rabit/rabit/Goal/Models/CertifiableTime.swift
+++ b/rabit/rabit/Goal/Models/CertifiableTime.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CertifiableTime: CustomStringConvertible {
+struct CertifiableTime: CustomStringConvertible, Equatable {
     
     // 지정한 요일에, 시작~끝 시간 동안만 인증이 가능
     let start: TimeComponent
@@ -12,10 +12,6 @@ struct CertifiableTime: CustomStringConvertible {
     }
     
     init() {
-        let currDate = Date()
-        let start = currDate.toTimeComponent()
-        let end = Calendar.current.date(byAdding: .hour, value: 5, to: currDate)?.toTimeComponent() ?? start
-       
         self.start = TimeComponent(hour: 9)
         self.end =  TimeComponent(hour: 21)
         self.days = Days()

--- a/rabit/rabit/Goal/Models/Days.swift
+++ b/rabit/rabit/Goal/Models/Days.swift
@@ -37,7 +37,7 @@ extension Day: Comparable {
     }
 }
 
-struct Days: CustomStringConvertible {
+struct Days: CustomStringConvertible, Equatable {
     
     let selectedValues: Set<Day>
     

--- a/rabit/rabit/Goal/Models/Goal.swift
+++ b/rabit/rabit/Goal/Models/Goal.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Differentiator
 
 @propertyWrapper
 struct DayCountable {
@@ -24,8 +25,9 @@ struct DayCountable {
     }
 }
 
-struct Goal {
+struct Goal: Equatable {
     
+    let uuid: UUID
     let title: String
     let subtitle: String
     var progress: Int
@@ -35,7 +37,17 @@ struct Goal {
     var target: Int
     let creationDate: Date
     
-    init(title: String, subtitle: String, progress: Int = .zero, period: Period, certTime: CertifiableTime, category: String, creationDate: Date = Date()) {
+    init(
+        uuid: UUID = UUID(),
+        title: String,
+        subtitle: String,
+        progress: Int = .zero,
+        period: Period,
+        certTime: CertifiableTime,
+        category: String,
+        creationDate: Date = Date()
+    ) {
+        self.uuid = uuid
         self.title = title
         self.subtitle = subtitle
         self.progress = progress
@@ -51,9 +63,18 @@ struct Goal {
     }
 }
 
+extension Goal: IdentifiableType {
+    typealias identifier = UUID
+    
+    var identity: UUID {
+        return uuid
+    }
+}
+
 extension Goal: Persistable {
     
     init(entity: GoalEntity) {
+        self.uuid = entity.uuid
         self.title = entity.title
         self.subtitle = entity.subtitle
         self.progress = entity.progress
@@ -70,6 +91,7 @@ extension Goal: Persistable {
     
     func toEntity<T: GoalEntity>() -> T {
         .init(
+            uuid: uuid,
             title: title,
             subtitle: subtitle,
             progress: progress,

--- a/rabit/rabit/Goal/Models/Goal.swift
+++ b/rabit/rabit/Goal/Models/Goal.swift
@@ -35,7 +35,7 @@ struct Goal: Equatable {
     let certTime: CertifiableTime
     let category: String
     var target: Int
-    let creationDate: Date
+    let createdDate: Date
     
     init(
         uuid: UUID = UUID(),
@@ -45,7 +45,7 @@ struct Goal: Equatable {
         period: Period,
         certTime: CertifiableTime,
         category: String,
-        creationDate: Date = Date()
+        createdDate: Date = Date()
     ) {
         self.uuid = uuid
         self.title = title
@@ -54,7 +54,7 @@ struct Goal: Equatable {
         self.period = period
         self.certTime = certTime
         self.category = category
-        self.creationDate = creationDate
+        self.createdDate = createdDate
         
         @DayCountable(period: period, days: certTime.days.selectedValues)
         var target
@@ -86,7 +86,7 @@ extension Goal: Persistable {
                             end: entity.endCertTime,
                             days: Days(entity.certDays)
                         )
-        self.creationDate = entity.creationDate
+        self.createdDate = entity.createdDate
     }
     
     func toEntity<T: GoalEntity>() -> T {
@@ -99,7 +99,7 @@ extension Goal: Persistable {
             category: category,
             period: period,
             certTime: certTime,
-            creationDate: creationDate
+            createdDate: createdDate
         )
     }
 }

--- a/rabit/rabit/Goal/Models/Goal.swift
+++ b/rabit/rabit/Goal/Models/Goal.swift
@@ -33,14 +33,16 @@ struct Goal {
     let certTime: CertifiableTime
     let category: String
     var target: Int
+    let creationDate: Date
     
-    init(title: String, subtitle: String, progress: Int = .zero, period: Period, certTime: CertifiableTime, category: String) {
+    init(title: String, subtitle: String, progress: Int = .zero, period: Period, certTime: CertifiableTime, category: String, creationDate: Date = Date()) {
         self.title = title
         self.subtitle = subtitle
         self.progress = progress
         self.period = period
         self.certTime = certTime
         self.category = category
+        self.creationDate = creationDate
         
         @DayCountable(period: period, days: certTime.days.selectedValues)
         var target
@@ -63,6 +65,7 @@ extension Goal: Persistable {
                             end: entity.endCertTime,
                             days: Days(entity.certDays)
                         )
+        self.creationDate = entity.creationDate
     }
     
     func toEntity<T: GoalEntity>() -> T {
@@ -73,7 +76,8 @@ extension Goal: Persistable {
             target: target,
             category: category,
             period: period,
-            certTime: certTime
+            certTime: certTime,
+            creationDate: creationDate
         )
     }
 }

--- a/rabit/rabit/Goal/Models/GoalEntity.swift
+++ b/rabit/rabit/Goal/Models/GoalEntity.swift
@@ -3,7 +3,7 @@ import RealmSwift
 
 final class GoalEntity: Object {
     
-    @Persisted var uuid: UUID = UUID()
+    @Persisted var uuid: UUID
     @Persisted var title: String = ""
     @Persisted var subtitle: String = ""
     @Persisted var progress: Int = 0
@@ -17,6 +17,7 @@ final class GoalEntity: Object {
     @Persisted var creationDate: Date
     
     convenience init(
+        uuid: UUID,
         title: String,
         subtitle: String,
         progress: Int,
@@ -27,6 +28,7 @@ final class GoalEntity: Object {
         creationDate: Date) {
             self.init()
             
+            self.uuid = uuid
             self.title = title
             self.subtitle = subtitle
             self.progress = progress

--- a/rabit/rabit/Goal/Models/GoalEntity.swift
+++ b/rabit/rabit/Goal/Models/GoalEntity.swift
@@ -14,6 +14,7 @@ final class GoalEntity: Object {
     @Persisted var startCertTime: Int = 0
     @Persisted var endCertTime: Int = 0
     @Persisted var certDays: List<Int> = List()
+    @Persisted var creationDate: Date
     
     convenience init(
         title: String,
@@ -22,20 +23,22 @@ final class GoalEntity: Object {
         target: Int,
         category: String,
         period: Period,
-        certTime: CertifiableTime) {
-        self.init()
-        
-        self.title = title
-        self.subtitle = subtitle
-        self.progress = progress
-        self.target = target
-        self.category = category
-        self.startDate = period.start
-        self.endDate = period.end
-        self.startCertTime = certTime.start.toSeconds()
-        self.endCertTime = certTime.end.toSeconds()
-        self.certDays.append(objectsIn: certTime.days.toIntArray())
-    }
+        certTime: CertifiableTime,
+        creationDate: Date) {
+            self.init()
+            
+            self.title = title
+            self.subtitle = subtitle
+            self.progress = progress
+            self.target = target
+            self.category = category
+            self.startDate = period.start
+            self.endDate = period.end
+            self.startCertTime = certTime.start.toSeconds()
+            self.endCertTime = certTime.end.toSeconds()
+            self.certDays.append(objectsIn: certTime.days.toIntArray())
+            self.creationDate = creationDate
+        }
     
     override static func primaryKey() -> String? {
         return "uuid"

--- a/rabit/rabit/Goal/Models/GoalEntity.swift
+++ b/rabit/rabit/Goal/Models/GoalEntity.swift
@@ -14,7 +14,7 @@ final class GoalEntity: Object {
     @Persisted var startCertTime: Int = 0
     @Persisted var endCertTime: Int = 0
     @Persisted var certDays: List<Int> = List()
-    @Persisted var creationDate: Date
+    @Persisted var createdDate: Date
     
     convenience init(
         uuid: UUID,
@@ -25,7 +25,7 @@ final class GoalEntity: Object {
         category: String,
         period: Period,
         certTime: CertifiableTime,
-        creationDate: Date) {
+        createdDate: Date) {
             self.init()
             
             self.uuid = uuid
@@ -39,7 +39,7 @@ final class GoalEntity: Object {
             self.startCertTime = certTime.start.toSeconds()
             self.endCertTime = certTime.end.toSeconds()
             self.certDays.append(objectsIn: certTime.days.toIntArray())
-            self.creationDate = creationDate
+            self.createdDate = createdDate
         }
     
     override static func primaryKey() -> String? {

--- a/rabit/rabit/Goal/Models/Period.swift
+++ b/rabit/rabit/Goal/Models/Period.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Period {
+struct Period: Equatable {
     
     let start: Date
     let end: Date


### PR DESCRIPTION
close #95 

- [x] 카테고리 및 목표 리스트를 '생성날짜'를 기준으로 오름차순 정렬되도록 처리
- [x] 기존에 Goal에 IdentifiableType이 채택되있지 않았던 것을 채택하도록 처리 

간단하게 작업했어요 ㅎㅎ 시간나실 때 확인 부탁드려요~!
