### PR TITLE
RealmManager 개선

### DIFF
--- a/rabit/rabit/Common/RealmManager.swift
+++ b/rabit/rabit/Common/RealmManager.swift
@@ -19,7 +19,7 @@ final class RealmManager {
                 return
             }
             
-            let realm = try! Realm(configuration: self.configuration, queue: self.realmSerialQueue)
+            let realm = try! Realm(configuration: self.configuration, queue: self.realmSerialQueue).freeze()
             
             if let query = query {
                 result = realm.objects(entity).filter(query).toArray(ofType: entity)


### PR DESCRIPTION
RealmManager을 개선해봤는데 요약하면 크게 2가지입니다.
- Realm에 접근할 때 특정 serial queue에만 접근하도록 수정
    - 이전에는 메인스레드에서만 Realm에 접근하고 있었는데, 메인 스레드의 부담을 줄이고자 특정 백그라운드 스레드에서만 접근할 수 있도록 RealmManager 내부에 별도의 serial queue를 두고 작업을 할당하도록 했습니다.
- Realm에서 읽어들인 Object를 Repository로 넘길 때 frozen object의 형태로 넘기도록 수정
    - Realm 객체 뿐만 아니라, 읽어들인 Entity들도 모두 Realm을 생성한 스레드와 동일한 스레드에서만 접근해야 한다고 합니다... 그래서 Entity를 바로 넘기지 않고, `freeze()` 를 한 번 호출시켜서 Realm 객체를 frozen object로 만들으서 데이터를 읽도록 했습니다.
    - 공식문서를 보면 스레드 간에 Realm에서 읽어들인 live object를 넘길 수 없고, `freeze()` 를 통해 frozen object로 만들어서 넘겨야 한다고 하네요!   