### PR TITLE
RangeSlider의 Step(단위)를 변경할 수 있는 기능 추가

### DIFF
--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -178,6 +178,7 @@ final class RangeSlider: UIControl {
         if prevLeftValue != leftValue || prevRightValue != rightValue {
             feedbackGenerator?.selectionChanged()
         }
+        feedbackGenerator?.prepare()
         
         previousTouchedPoint = touchedPoint
         sendActions(for: .valueChanged)

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -148,7 +148,13 @@ final class RangeSlider: UIControl {
     override func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
         super.continueTracking(touch, with: event)
         
-        let touchedPoint = touch.location(in: self)
+        let sliderWidth = self.frame.width
+        let sliderTimeRange: CGFloat = ((24 * 60 - 2) / 10) // (24시간 - 2분) / 10분
+        let step: CGFloat = sliderWidth / sliderTimeRange
+        let touchedPoint = CGPoint(
+            x: round(touch.location(in: self).x / step) * step,
+            y: touch.location(in: self).y
+        )
         let draggedValue = Double(touchedPoint.x - previousTouchedPoint.x)
         let scale = maxValue - minValue
         let scaledValue = scale * draggedValue / widthWithoutThumb

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -183,8 +183,8 @@ final class RangeSlider: UIControl {
             rightValue = (rightValue + scaledValue).clamped(to: leftValue...maxValue)
         }
         
-        // Thumb이 이동했을 경우에만 햅틱 피드백
-        if prevLeftValue != leftValue || prevRightValue != rightValue {
+        let isThumbMoved = prevLeftValue != leftValue || prevRightValue != rightValue
+        if isThumbMoved {
             feedbackGenerator?.selectionChanged()
         }
         feedbackGenerator?.prepare()

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -55,6 +55,8 @@ final class RangeSlider: UIControl {
         didSet { self.rightValue = maxValue }
     }
     
+    private var step: CGFloat = 1.0
+    
     lazy var leftValue: Double = minValue {
         didSet { self.updateLayout(to: leftValue, direction: .left) }
     }
@@ -75,11 +77,12 @@ final class RangeSlider: UIControl {
         }
     }
     
-    convenience init(min: Double, max: Double) {
+    convenience init(min: Double, max: Double, step: CGFloat = 1.0) {
         self.init()
         
         self.minValue = min
         self.maxValue = max
+        self.step = step
         
         setupViews()
     }
@@ -157,9 +160,6 @@ final class RangeSlider: UIControl {
         let prevLeftValue = self.leftValue
         let prevRightValue = self.rightValue
         
-        let sliderWidth = self.frame.width
-        let sliderTimeRange: CGFloat = ((24 * 60 - 2) / 10) // (24시간 - 2분) / 10분
-        let step: CGFloat = sliderWidth / sliderTimeRange
         let touchedPoint = CGPoint(
             x: round(touch.location(in: self).x / step) * step,
             y: touch.location(in: self).y

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -46,6 +46,7 @@ final class RangeSlider: UIControl {
     }
     
     private var feedbackGenerator: UISelectionFeedbackGenerator? = nil
+    private var isFeedbackRequested: Bool = true
     
     private var minValue: Double = 0.0 {
         didSet { self.leftValue = minValue }
@@ -77,12 +78,18 @@ final class RangeSlider: UIControl {
         }
     }
     
-    convenience init(min: Double, max: Double, step: CGFloat = 1.0) {
+    convenience init(
+        min: Double,
+        max: Double,
+        step: CGFloat = 1.0,
+        feedbackRequest: Bool = true
+    ) {
         self.init()
         
         self.minValue = min
         self.maxValue = max
         self.step = step
+        self.isFeedbackRequested = feedbackRequest
         
         setupViews()
     }
@@ -138,8 +145,10 @@ final class RangeSlider: UIControl {
     override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
         super.beginTracking(touch, with: event)
         
-        feedbackGenerator = UISelectionFeedbackGenerator()
-        feedbackGenerator?.prepare()
+        if isFeedbackRequested {
+            feedbackGenerator = UISelectionFeedbackGenerator()
+            feedbackGenerator?.prepare()
+        }
         
         let touchedPoint = touch.location(in: self)
         isLeftThumbTouched = leftThumbButton.frame.contains(touchedPoint)

--- a/rabit/rabit/Common/Views/RangeSlider.swift
+++ b/rabit/rabit/Common/Views/RangeSlider.swift
@@ -178,7 +178,6 @@ final class RangeSlider: UIControl {
         if prevLeftValue != leftValue || prevRightValue != rightValue {
             feedbackGenerator?.selectionChanged()
         }
-        feedbackGenerator?.prepare()
         
         previousTouchedPoint = touchedPoint
         sendActions(for: .valueChanged)

--- a/rabit/rabit/Goal/Models/TimeComponent.swift
+++ b/rabit/rabit/Goal/Models/TimeComponent.swift
@@ -21,7 +21,7 @@ struct TimeComponent: Equatable {
     
     init(rawValue seconds: Int) {
         self.hour = seconds/3600
-        self.minute = (seconds % 3600) / 60
+        self.minute = (seconds % 3600) / 600 * 10
         self.seconds = (seconds % 3600) % 60
     }
     

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -29,8 +29,14 @@ final class TimeSelectViewController: UIViewController {
         return sheet
     }()
     
-    private let timeRangeSlider: RangeSlider = {
-        let slider = RangeSlider(min: 60, max: 60*60*23 + 60*59)
+    private lazy var timeRangeSliderHeight = view.bounds.width - 40
+    private lazy var timeRangeSlider: RangeSlider = {
+        let sliderTimeRange: CGFloat = (24 * 60 - 2) / 10 // (24시간 - 2분) / 10분
+        let slider = RangeSlider(
+            min: 60,
+            max: 60*60*23 + 60*59,
+            step: timeRangeSliderHeight / sliderTimeRange
+        )
         return slider
     }()
     
@@ -215,7 +221,8 @@ final class TimeSelectViewController: UIViewController {
         timeSelectSheet.contentView.addSubview(timeRangeSlider)
         timeRangeSlider.snp.makeConstraints {
             $0.top.equalTo(timePreviewLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(timeRangeSliderHeight)
             $0.height.equalToSuperview().multipliedBy(0.08)
         }
         

--- a/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
+++ b/rabit/rabit/Goal/TimeSelect/TimeSelectViewController.swift
@@ -29,13 +29,13 @@ final class TimeSelectViewController: UIViewController {
         return sheet
     }()
     
-    private lazy var timeRangeSliderHeight = view.bounds.width - 40
+    private lazy var timeRangeSliderWidth = view.bounds.width - 40
     private lazy var timeRangeSlider: RangeSlider = {
         let sliderTimeRange: CGFloat = (24 * 60 - 2) / 10 // (24시간 - 2분) / 10분
         let slider = RangeSlider(
             min: 60,
             max: 60*60*23 + 60*59,
-            step: timeRangeSliderHeight / sliderTimeRange
+            step: timeRangeSliderWidth / sliderTimeRange
         )
         return slider
     }()
@@ -222,7 +222,7 @@ final class TimeSelectViewController: UIViewController {
         timeRangeSlider.snp.makeConstraints {
             $0.top.equalTo(timePreviewLabel.snp.bottom).offset(10)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(timeRangeSliderHeight)
+            $0.width.equalTo(timeRangeSliderWidth)
             $0.height.equalToSuperview().multipliedBy(0.08)
         }
         


### PR DESCRIPTION
- 사용자가 TimeSelectVC에서 인증시간을 선택할 때, 1분 단위로 Slider를 조정하게 되면 정확한 시간으로 설정하려고 할 때 불편한 경험을 하게 될 것이라 생각했습니다.
- 따라서 TimeSelectVC의 RangeSlider의 단위를 10분으로 변경하려고 했습니다.
    이를 계산하기 위해, Slider의 Thumb 1칸 이동에 대한 단위를 수정해야 했습니다.
    먼저, 10분 단위를 만들기 위해, 현재 사용하는 Slider의 전체 범위(0시1분~11시59분)를 10(분)으로 나누었습니다.
    그리고 Slider의 전체 넓이를 위에서 구한 값으로 나눈 값으로 touchedPoint.x를 나누어준 후 반올림(round)하여 그 나머지를 버리고 다시 곱해줌으로써 Slider의 1칸의 단위를 10분으로 설정할 수 있었습니다.
    ```swift
    let step = self.frame.width / ((24 * 60 - 2) / 10)
    let touchedPoint = CGPoint(
        x: round(touch.location(in: self) / step) * step,
        y: touch.location(in: self)
    )
    ```
- 위와 같이 RangeSlider 내의 `continueTracking(_:with:)` 메소드를 수정했으나, 하나의 모듈인 RangeSlider 로써의 의미를 살리기 위해 RangeSlider가 Step(단위)와 관련된 값을 private property로 가지도록 하고, 이를 RangeSlider 초기화 시에 정해줄 수 있도록 초기화 생성자의 매개변수로 받았습니다.
- 또한, Slider의 1칸 이동이 1분이 아니라는 것(큰 값이라는 것)을 사용자가 인식하기 쉽도록 Slider Thumb 이동 시에 햅틱 피드백을 주도록 했습니다.

---

- 추가적으로 공유드리고 싶은 내용이 있는데, 먼저 RangeSlider의 LeftThumb의 경우 오른쪽으로 쭉 밀면 RightThumb를 밀어내는 듯한 화면이 표현됩니다. RightValue는 변경되지 않지만, RightValue == LeftValue가 되는 경우에 그렇게 RightThumb를 밀어내는 것 같습니다.(웃긴게 그 반대 경우일 때 RightThumb은 LeftThumb를 밀지 않더라고요..ㅋㅋㅋ 이게 제 생각에는 LeftThumb가 가지는 LeftValue와 Thumb 위치 관계가 RightThumb가 가지는 RightValue와 Thumb 위치 관계가 달라서 그런 문제가 있는 것 같아요!)
- 그리고 알람을 주는 경우를 생각해보다보니, LeftValue, RightValue 간에 어느 정도 간격 제한이 있어야 의미있는 알람을 줄 수 있지 않을까 생각했습니다! 예를 들어 LeftValue == RightValue인 경우에는 인증할 수 있는 시간이 0초가 되기 때문에 제한이 필요하다고 느꼈습니다.
    그래서 위의 첫 번째 공유 내용과 합쳐보고, Thumb 끼리 겹치지 않는 범위 내에 LeftValue, RightValue 간 간격 제한을 주도록 하는게 좋을 것 같다고 생각하여 그렇게 해봤는데, 그럴 경우 간격 제한이 약 120~130분 정도 되어야하는데, 이게 의미있는 값일까 하는 생각이 들어서 더이상 진행하지 않았습니다!
    RangeSlider 구현 내용에 대해 더 살펴보고 제드랑 의견 나눠봐야 할 거 같습니다!ㅎㅎ