### PR TITLE
목표 삭제 기능 구현

### DIFF
--- a/rabit/rabit/Common/RealmManager.swift
+++ b/rabit/rabit/Common/RealmManager.swift
@@ -29,4 +29,10 @@ final class RealmManager {
             realm.add(entity, update: .modified)
         }
     }
+    
+    func delete<T: Object>(entity: T) throws {
+        try? realm.write {
+            realm.delete(entity)
+        }
+    }
 }

--- a/rabit/rabit/Goal/GoalListRepository.swift
+++ b/rabit/rabit/Goal/GoalListRepository.swift
@@ -20,7 +20,7 @@ final class GoalListRepository {
     }
     
     //삭제 대상이 되는 특정 Entity를 우선 읽어들인 후, 삭제 트랜잭션으로 전달
-    func deleteGoal(goal: Goal) -> Single<Result<Goal,Error>> {
+    func deleteGoal(_ goal: Goal) -> Single<Result<Goal,Error>> {
         
         return .create { [weak self] single in
             guard let realmManager = self?.realmManager,

--- a/rabit/rabit/Goal/GoalListViewController.swift
+++ b/rabit/rabit/Goal/GoalListViewController.swift
@@ -55,8 +55,10 @@ final class GoalListViewController: UIViewController {
 
                 let actionSheetMenu = UIAlertController(title: nil, message: "옵션 선택", preferredStyle: .actionSheet)
 
-                let deleteAction = UIAlertAction(title: "목표 삭제하기", style: .default, handler: { _ in
-                    viewModel.deleteGoal.accept(goal)
+                let deleteAction = UIAlertAction(title: "목표 삭제하기", style: .destructive, handler: { _ in
+                    viewController.showAlert(message: "정말 삭제하시겠습니까?", activateCancelAction: true) {
+                        viewModel.deleteGoal.accept(goal)
+                    }
                 })
                 let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
                 
@@ -70,12 +72,7 @@ final class GoalListViewController: UIViewController {
         viewModel.showAlert
             .withUnretained(self)
             .bind(onNext: { viewController, message in
-                
-                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                let confirmAction = UIAlertAction(title: "확인", style: .default)
-                alert.addAction(confirmAction)
-                
-                viewController.present(alert, animated: true, completion: nil)
+                viewController.showAlert(message: message)
             })
             .disposed(by: disposeBag)
     }
@@ -97,6 +94,28 @@ final class GoalListViewController: UIViewController {
 }
 
 private extension GoalListViewController {
+    
+    func showActionSheet() {
+        
+    }
+    
+    func showAlert(title: String? = nil, message: String, activateCancelAction: Bool = false, actionHandler: (() -> Void)? = nil) {
+        
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "확인", style: .default, handler: { _ in
+            if let actionHandler = actionHandler {
+                actionHandler()
+            }
+        })
+        alert.addAction(confirmAction)
+        
+        if activateCancelAction {
+            let cancelAction = UIAlertAction(title: "취소", style: .destructive)
+            alert.addAction(cancelAction)
+        }
+        
+        self.present(alert, animated: true, completion: nil)
+    }
     
     func initializeDataSource() -> RxCollectionViewSectionedReloadDataSource<Category> {
         let viewModel = viewModel

--- a/rabit/rabit/Goal/GoalListViewController.swift
+++ b/rabit/rabit/Goal/GoalListViewController.swift
@@ -31,12 +31,6 @@ final class GoalListViewController: UIViewController {
         bind()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        viewModel?.requestGoalList.accept(())
-    }
-    
     private func bind() {
         guard let viewModel = viewModel else { return }
         
@@ -52,6 +46,8 @@ final class GoalListViewController: UIViewController {
         goalListCollectionView.rx.modelSelected(Goal.self)
             .bind(to: viewModel.showGoalDetailView)
             .disposed(by: disposeBag)
+        
+        viewModel.requestGoalList.accept(())
     }
     
     private func setupViews() {

--- a/rabit/rabit/Goal/GoalListViewController.swift
+++ b/rabit/rabit/Goal/GoalListViewController.swift
@@ -56,7 +56,7 @@ final class GoalListViewController: UIViewController {
                 let actionSheetMenu = UIAlertController(title: nil, message: "옵션 선택", preferredStyle: .actionSheet)
 
                 let deleteAction = UIAlertAction(title: "목표 삭제하기", style: .default, handler: { _ in
-                    print("삭제",goal.title,goal.category)
+                    viewModel.deleteGoal.accept(goal)
                 })
                 let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
                 
@@ -64,6 +64,18 @@ final class GoalListViewController: UIViewController {
                 actionSheetMenu.addAction(cancelAction)
                 
                 viewController.present(actionSheetMenu, animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.showAlert
+            .withUnretained(self)
+            .bind(onNext: { viewController, message in
+                
+                let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                let confirmAction = UIAlertAction(title: "확인", style: .default)
+                alert.addAction(confirmAction)
+                
+                viewController.present(alert, animated: true, completion: nil)
             })
             .disposed(by: disposeBag)
     }

--- a/rabit/rabit/Goal/GoalListViewController.swift
+++ b/rabit/rabit/Goal/GoalListViewController.swift
@@ -95,10 +95,6 @@ final class GoalListViewController: UIViewController {
 
 private extension GoalListViewController {
     
-    func showActionSheet() {
-        
-    }
-    
     func showAlert(title: String? = nil, message: String, activateCancelAction: Bool = false, actionHandler: (() -> Void)? = nil) {
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -110,7 +106,7 @@ private extension GoalListViewController {
         alert.addAction(confirmAction)
         
         if activateCancelAction {
-            let cancelAction = UIAlertAction(title: "취소", style: .destructive)
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
             alert.addAction(cancelAction)
         }
         

--- a/rabit/rabit/Goal/GoalListViewController.swift
+++ b/rabit/rabit/Goal/GoalListViewController.swift
@@ -48,6 +48,24 @@ final class GoalListViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel.requestGoalList.accept(())
+        
+        viewModel.showActionSheetMenu
+            .withUnretained(self)
+            .bind(onNext: { viewController, goal in
+
+                let actionSheetMenu = UIAlertController(title: nil, message: "옵션 선택", preferredStyle: .actionSheet)
+
+                let deleteAction = UIAlertAction(title: "목표 삭제하기", style: .default, handler: { _ in
+                    print("삭제",goal.title,goal.category)
+                })
+                let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
+                
+                actionSheetMenu.addAction(deleteAction)
+                actionSheetMenu.addAction(cancelAction)
+                
+                viewController.present(actionSheetMenu, animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func setupViews() {
@@ -80,6 +98,7 @@ private extension GoalListViewController {
                 }
                 
                 cell.configure(goal: goal)
+                cell.bind(to: viewModel, with: goal)
                 
                 return cell
             },

--- a/rabit/rabit/Goal/GoalListViewModel.swift
+++ b/rabit/rabit/Goal/GoalListViewModel.swift
@@ -62,11 +62,14 @@ private extension GoalListViewModel {
             .bind(to: showActionSheetMenu)
             .disposed(by: disposeBag)
         
-        deleteGoal
+        let deleteGoalResult =  deleteGoal
             .withUnretained(self)
             .flatMapLatest { viewModel, goal in
                 viewModel.repository.deleteGoal(goal)
             }
+            .share()
+
+        deleteGoalResult
             .withUnretained(self)
             .bind(onNext: { viewModel, result in
                 switch result {

--- a/rabit/rabit/Goal/GoalListViewModel.swift
+++ b/rabit/rabit/Goal/GoalListViewModel.swift
@@ -14,6 +14,7 @@ protocol GoalListViewModelInput {
 protocol GoalListViewModelOutput {
     
     var goalList: PublishRelay<[Category]> { get }
+    var showActionSheetMenu: PublishRelay<Goal> { get }
 }
 
 protocol GoalListViewModelProtocol: GoalListViewModelInput, GoalListViewModelOutput {}
@@ -26,6 +27,7 @@ final class GoalListViewModel: GoalListViewModelProtocol {
     let cellMenuButtonTapped = PublishRelay<Goal>()
     let goalList = PublishRelay<[Category]>()
     let showGoalDetailView = PublishRelay<Goal>()
+    let showActionSheetMenu = PublishRelay<Goal>()
     
     private let repository: GoalListRepository
     private let disposeBag = DisposeBag()

--- a/rabit/rabit/Goal/GoalListViewModel.swift
+++ b/rabit/rabit/Goal/GoalListViewModel.swift
@@ -65,7 +65,7 @@ private extension GoalListViewModel {
         deleteGoal
             .withUnretained(self)
             .flatMapLatest { viewModel, goal in
-                viewModel.repository.deleteGoal(goal: goal)
+                viewModel.repository.deleteGoal(goal)
             }
             .withUnretained(self)
             .bind(onNext: { viewModel, result in

--- a/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
+++ b/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
@@ -59,13 +59,22 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(goal: Goal) {
-
-        titleLabel.text = goal.title
-        subTitleLabel.text = goal.subtitle
         
-        guard goal.target != 0 else { return }
-        let ratio = CGFloat(goal.progress) /  CGFloat(goal.target)
-        goalProgressView.progress = ratio
+        setTitles(title: goal.title, subTitle: goal.subtitle)
+        setProgress(target: goal.target, progress: goal.progress)
+        
+        func setTitles(title: String, subTitle: String) {
+            titleLabel.text = title
+            subTitleLabel.text = subTitle
+        }
+        
+        func setProgress(target: Int, progress: Int) {
+            guard target != 0 else { return }
+            let ratio = CGFloat(progress) /  CGFloat(target)
+            goalProgressView.progress = ratio
+        }
+    }
+    
     func bind(to viewModel: GoalListViewModelProtocol?, with goal: Goal) {
         guard let viewModel = viewModel else { return }
 

--- a/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
+++ b/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
@@ -78,8 +78,7 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
     func bind(to viewModel: GoalListViewModelProtocol?, with goal: Goal) {
         guard let viewModel = viewModel else { return }
 
-        menuButton.rx.tapGesture()
-            .when(.ended)
+        menuButton.rx.tap
             .map { _ in goal }
             .bind(to: viewModel.cellMenuButtonTapped)
             .disposed(by: disposeBag)

--- a/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
+++ b/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
@@ -33,6 +33,12 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
         return progressView
     }()
     
+    private let menuButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        return button
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -78,8 +84,14 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
             make.top.equalToSuperview().offset(24/750 * UIScreen.main.bounds.height)
             make.centerY.equalToSuperview()
         }
-        
         titleStackView.addArrangedSubview(titleLabel)
         titleStackView.addArrangedSubview(subTitleLabel)
+        
+        contentView.addSubview(menuButton)
+        menuButton.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.bottom.equalTo(titleStackView.snp.top)
+            make.trailing.equalToSuperview().inset(20/376 * UIScreen.main.bounds.width)
+        }
     }
 }

--- a/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
+++ b/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SnapKit
+import RxSwift
 
 final class GoalListCollectionViewCell: UICollectionViewCell {
     
@@ -39,6 +40,8 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
         return button
     }()
     
+    private var disposeBag = DisposeBag()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -50,6 +53,11 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+    
     func configure(goal: Goal) {
 
         titleLabel.text = goal.title
@@ -58,8 +66,16 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
         guard goal.target != 0 else { return }
         let ratio = CGFloat(goal.progress) /  CGFloat(goal.target)
         goalProgressView.progress = ratio
+    func bind(to viewModel: GoalListViewModelProtocol?, with goal: Goal) {
+        guard let viewModel = viewModel else { return }
+
+        menuButton.rx.tapGesture()
+            .when(.ended)
+            .map { _ in goal }
+            .bind(to: viewModel.cellMenuButtonTapped)
+            .disposed(by: disposeBag)
     }
-            
+    
     private func setAttributes() {
         
         contentView.layer.borderWidth = 1.0

--- a/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
+++ b/rabit/rabit/Goal/Views/GoalListCollectionViewCell.swift
@@ -62,17 +62,6 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
         
         setTitles(title: goal.title, subTitle: goal.subtitle)
         setProgress(target: goal.target, progress: goal.progress)
-        
-        func setTitles(title: String, subTitle: String) {
-            titleLabel.text = title
-            subTitleLabel.text = subTitle
-        }
-        
-        func setProgress(target: Int, progress: Int) {
-            guard target != 0 else { return }
-            let ratio = CGFloat(progress) /  CGFloat(target)
-            goalProgressView.progress = ratio
-        }
     }
     
     func bind(to viewModel: GoalListViewModelProtocol?, with goal: Goal) {
@@ -117,5 +106,17 @@ final class GoalListCollectionViewCell: UICollectionViewCell {
             make.bottom.equalTo(titleStackView.snp.top)
             make.trailing.equalToSuperview().inset(20/376 * UIScreen.main.bounds.width)
         }
+    }
+    
+    private func setTitles(title: String, subTitle: String) {
+        titleLabel.text = title
+        subTitleLabel.text = subTitle
+    }
+    
+    private func setProgress(target: Int, progress: Int) {
+        guard target != 0 else { return }
+        
+        let ratio = CGFloat(progress) /  CGFloat(target)
+        goalProgressView.progress = ratio
     }
 }


### PR DESCRIPTION
close #108 

- 원래는 셀을 오른쪽에서 왼쪽으로 Swipe 하는 식으로 구현하려 했는데, 아래와 같은 이유로 따로 액션 시트를 보여주는 UI를 추가한 후, 여기서 사용자가 삭제 여부를 선택할 있도록 구현했어요
 (좀 보기 이상한 UI다 싶으면 같이 얘기해보고  기능 유지한채로 디자인만 다시 수정하면 될듯합니다!)
    - Compositional Layout 내부에서 UISwipeAction을 추가할 경우에는, 이 때 사용하는 타입이 iOS14 이상에서만 사용 가능
    - UIContextualAction 과 같은 경우에는 보통 테이블뷰의 delegate method 안에서 사용하거나, 컬렉션뷰에 적용한다 하더라도 비슷하게 delegate method를 사용해야 함
    - 이럴 경우 (우선 여러가지 시도해본바로는) 코드가 너무 복잡해질 뿐더러, 무엇보다 부가 메뉴가 존재함을 알 수 있는 UI 요소가 없으면 사용자 입장에서 Swipe Action을 통해 무언가를 할 수 있다는 사실을 알기 어렵겠다고 생각
    - 결국 위와 같은 이유로 액션 시트를 보여주는 UI 요소를 우선 구현하고, 이를 터치했을 때 화면에 삭제 여부를 선택할 수 있는 액션 시트를 보여주도록 함

![Simulator Screen Recording - iPhone 12 mini - 2022-11-27 at 23 19 28](https://user-images.githubusercontent.com/68586291/204140116-da86cfb6-0ada-44eb-8eb4-f404bf3edb35.gif)
