### PR TITLE
이미지 저장+불러오기 로직 변경

### DIFF
--- a/rabit/rabit/Album/AlbumViewController.swift
+++ b/rabit/rabit/Album/AlbumViewController.swift
@@ -168,8 +168,13 @@ private extension AlbumViewController {
         )
 
         DispatchQueue.global().async {
-            guard let downsampledCGImage = prefetchTarget.imageData
-                .toDownsampledCGImage(pointSize: imageSize, scale: 0.5) else { return }
+            guard let imageData = prefetchTarget.imageData,
+                  let downsampledCGImage = imageData
+                        .toDownsampledCGImage(
+                            pointSize: imageSize,
+                            scale: 0.5
+                        ) else { return }
+
             let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {
@@ -186,10 +191,10 @@ private extension AlbumViewController {
         return { (dataSource, collectionView, indexPath, item) in
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: AlbumCell.identifier,
-                for: indexPath) as? AlbumCell else { return UICollectionViewCell() }
+                for: indexPath
+            ) as? AlbumCell else { return UICollectionViewCell() }
 
             let itemData = dataSource.sectionModels[indexPath.section].items[indexPath.item]
-
             cell.configure(with: itemData)
             return cell
         }

--- a/rabit/rabit/Album/AlbumViewModel.swift
+++ b/rabit/rabit/Album/AlbumViewModel.swift
@@ -63,9 +63,6 @@ private extension AlbumViewModel {
             .map { viewModel, newData, indexPath in
                 var albumData = viewModel.albumData.value
                 albumData[indexPath.section].items[indexPath.item] = newData
-                if let imageData = newData.imageData {
-                    viewModel.albumRepository.savePhotoImageData(imageData, name: newData.imageName)
-                }
 
                 return albumData
             }

--- a/rabit/rabit/Album/AlbumViewModel.swift
+++ b/rabit/rabit/Album/AlbumViewModel.swift
@@ -63,6 +63,9 @@ private extension AlbumViewModel {
             .map { viewModel, newData, indexPath in
                 var albumData = viewModel.albumData.value
                 albumData[indexPath.section].items[indexPath.item] = newData
+                if let imageData = newData.imageData {
+                    viewModel.albumRepository.savePhotoImageData(imageData, name: newData.imageName)
+                }
 
                 return albumData
             }

--- a/rabit/rabit/Album/Models/Photo.swift
+++ b/rabit/rabit/Album/Models/Photo.swift
@@ -5,16 +5,17 @@ struct Photo: Equatable {
     let uuid: UUID
     let categoryTitle: String
     let goalTitle: String
-    let imageData: Data
+    let imageName: String
     let date: Date
     var color: String
     var style: Style
-
+    var imageData: Data?
+    
     init(
         uuid: UUID = UUID(),
         categoryTitle: String,
         goalTitle: String,
-        imageData: Data,
+        imageName: String,
         date: Date,
         color: String,
         style: Style
@@ -22,7 +23,7 @@ struct Photo: Equatable {
         self.uuid = uuid
         self.categoryTitle = categoryTitle
         self.goalTitle = goalTitle
-        self.imageData = imageData
+        self.imageName = imageName
         self.date = date
         self.color = color
         self.style = style
@@ -32,12 +33,12 @@ struct Photo: Equatable {
     init(
         categoryTitle: String,
         goalTitle: String,
-        imageData: Data
+        imageName: String
     ) {
         self.init(
             categoryTitle: categoryTitle,
             goalTitle: goalTitle,
-            imageData: imageData,
+            imageName: imageName,
             date: Date(),
             color: "#FFFFFF",
             style: .none
@@ -48,7 +49,7 @@ struct Photo: Equatable {
         self.init(
             categoryTitle: "",
             goalTitle: "",
-            imageData: Data(),
+            imageName: "",
             date: Date(),
             color: "",
             style: .none
@@ -70,7 +71,7 @@ extension Photo: Persistable {
             uuid: entity.uuid,
             categoryTitle: entity.categoryTitle,
             goalTitle: entity.goalTitle,
-            imageData: entity.imageData,
+            imageName: entity.imageName,
             date: entity.date,
             color: entity.color,
             style: Style(entity.style)
@@ -82,7 +83,7 @@ extension Photo: Persistable {
             uuid: self.uuid,
             categoryTitle: self.categoryTitle,
             goalTitle: self.goalTitle,
-            imageData: self.imageData,
+            imageName: self.imageName,
             date: self.date,
             color: self.color,
             style: self.style.rawValue

--- a/rabit/rabit/Album/Models/Photo.swift
+++ b/rabit/rabit/Album/Models/Photo.swift
@@ -18,7 +18,8 @@ struct Photo: Equatable {
         imageName: String,
         date: Date,
         color: String,
-        style: Style
+        style: Style,
+        imageData: Data? = nil
     ) {
         self.uuid = uuid
         self.categoryTitle = categoryTitle
@@ -27,13 +28,15 @@ struct Photo: Equatable {
         self.date = date
         self.color = color
         self.style = style
+        self.imageData = imageData
     }
 
     // Initializer for newly taken photo
     init(
         categoryTitle: String,
         goalTitle: String,
-        imageName: String
+        imageName: String,
+        imageData: Data?
     ) {
         self.init(
             categoryTitle: categoryTitle,
@@ -41,7 +44,8 @@ struct Photo: Equatable {
             imageName: imageName,
             date: Date(),
             color: "#FFFFFF",
-            style: .none
+            style: .none,
+            imageData: imageData
         )
     }
 

--- a/rabit/rabit/Album/Models/PhotoEntity.swift
+++ b/rabit/rabit/Album/Models/PhotoEntity.swift
@@ -5,7 +5,7 @@ final class PhotoEntity: Object {
     @Persisted var uuid: UUID = UUID()
     @Persisted var categoryTitle: String = ""
     @Persisted var goalTitle: String = ""
-    @Persisted var imageData: Data = Data()
+    @Persisted var imageName: String = ""
     @Persisted var date: Date = Date()
     @Persisted var color: String = ""
     @Persisted var style: String = ""
@@ -14,7 +14,7 @@ final class PhotoEntity: Object {
         uuid: UUID,
         categoryTitle: String,
         goalTitle: String,
-        imageData: Data,
+        imageName: String,
         date: Date,
         color: String,
         style: String
@@ -23,7 +23,7 @@ final class PhotoEntity: Object {
         self.uuid = uuid
         self.categoryTitle = categoryTitle
         self.goalTitle = goalTitle
-        self.imageData = imageData
+        self.imageName = imageName
         self.date = date
         self.color = color
         self.style = style

--- a/rabit/rabit/Album/Repository/AlbumRepository.swift
+++ b/rabit/rabit/Album/Repository/AlbumRepository.swift
@@ -4,6 +4,7 @@ import RxSwift
 protocol AlbumRepositoryProtocol {
     func fetchAlbumData() -> Single<[Album]>
     func updateAlbumData(_ data: Photo) -> Single<Bool>
+    func savePhotoImageData(_ data: Data, name: String)
 }
 
 final class AlbumRepository: AlbumRepositoryProtocol {
@@ -35,6 +36,22 @@ final class AlbumRepository: AlbumRepositoryProtocol {
 
             return Disposables.create()
         }
+    }
+    
+    func savePhotoImageData(_ data: Data, name: String) {
+        
+        guard let documentDirectory = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first else { return }
+        
+        let imageURL = documentDirectory.appendingPathComponent(name)
+        
+        if FileManager.default.fileExists(atPath: imageURL.path) {
+            try? FileManager.default.removeItem(at: imageURL)
+        }
+        
+        try? data.write(to: imageURL)
     }
 }
 
@@ -80,7 +97,7 @@ private extension AlbumRepository {
         
         if let directoryPath = path.first {
             let imageURL = URL(fileURLWithPath: directoryPath)
-                .appendingPathComponent("\(imageName).png")
+                .appendingPathComponent(imageName)
             
             return try? Data(contentsOf: imageURL)
         } else {

--- a/rabit/rabit/Album/Views/AlbumCell.swift
+++ b/rabit/rabit/Album/Views/AlbumCell.swift
@@ -37,8 +37,13 @@ final class AlbumCell: UICollectionViewCell {
         )
 
         DispatchQueue.global(qos: .userInteractive).async {
-            guard let downsampledCGImage = photo.imageData
-                .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
+            guard let imageData = photo.imageData,
+                  let  downsampledCGImage = imageData
+                        .toDownsampledCGImage(
+                            pointSize: imageSize,
+                            scale: 2.0
+                        ) else { return }
+            
             let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {

--- a/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewModel.swift
+++ b/rabit/rabit/Goal/CertPhotoCamera/CertPhotoCameraViewModel.swift
@@ -6,6 +6,7 @@ protocol CertPhotoCameraViewModelInput {
     
     var certPhotoDataInput: PublishRelay<Data> { get }
     var nextButtonTouched: PublishRelay<Void> { get }
+    var photoSaveResult: PublishRelay<Bool> { get }
 }
 protocol CertPhotoCameraViewModelOutput {
     
@@ -18,7 +19,11 @@ final class CertPhotoCameraViewModel: CertPhotoCameraViewModelProtocol {
     
     let certPhotoDataInput = PublishRelay<Data>()
     let nextButtonTouched = PublishRelay<Void>()
+    let photoSaveResult = PublishRelay<Bool>()
+    
     let previewPhotoData = PublishRelay<Data>()
+    
+    private var dateInfo: String
 
     private let repository: AlbumRepositoryProtocol
     
@@ -26,6 +31,7 @@ final class CertPhotoCameraViewModel: CertPhotoCameraViewModelProtocol {
     
     init(navigation: GoalNavigation, goal: Goal, repository: AlbumRepositoryProtocol) {
         self.repository = repository
+        self.dateInfo = Date().description.prefix(19).replacingOccurrences(of: " ", with: "_")
         
         bind(to: navigation, with: goal)
     }
@@ -39,26 +45,28 @@ private extension CertPhotoCameraViewModel {
             .bind(to: previewPhotoData)
             .disposed(by: disposeBag)
         
-        let imageSavedPhoto = nextButtonTouched
+        nextButtonTouched
             .withLatestFrom(previewPhotoData)
-            .withUnretained(self) { ($0, $1) }
-            .map { (viewModel, imageData) -> Photo in
-                let name = "\(Date().description.prefix(19).replacingOccurrences(of: " ", with: "_")).png"
-                viewModel.repository.savePhotoImageData(imageData, name: name)
-                
-                var photo = Photo.init(
-                    categoryTitle: goal.category,
-                    goalTitle: goal.title,
-                    imageName: name
-                )
-                photo.imageData = imageData
-
-                return photo
+            .withUnretained(self)
+            .flatMapLatest { (viewModel, imageData) -> Single<Bool> in
+                viewModel.dateInfo = Date().description.prefix(19).replacingOccurrences(of: " ", with: "_")
+                let name = "\(viewModel.dateInfo).png"
+                return viewModel.repository.savePhotoImageData(imageData, name: name)
             }
+            .bind(to: photoSaveResult)
+            .disposed(by: disposeBag)
         
-        imageSavedPhoto
-            .map(BehaviorRelay.init)
-            .bind(to: navigation.didTakeCertPhoto)
+        let imageSavedPhoto = photoSaveResult
+            .withLatestFrom(previewPhotoData)
+            .withUnretained(self) { (goal.category, goal.title, "\($0.dateInfo).png", $1) }
+            .map(Photo.init)
+        
+        photoSaveResult
+            .withLatestFrom(imageSavedPhoto) { ($0, $1) }
+            .bind { saveResult, photo in
+                guard saveResult == true else { return }
+                navigation.didTakeCertPhoto.accept(BehaviorRelay<Photo>(value: photo))
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/rabit/rabit/Goal/GoalCoordinator.swift
+++ b/rabit/rabit/Goal/GoalCoordinator.swift
@@ -176,7 +176,12 @@ private extension GoalCoordinator {
     
     func pushCertPhotoCameraView(with goal: Goal) {
         
-        let viewModel = CertPhotoCameraViewModel(navigation: self, goal: goal)
+        let repository = AlbumRepository()
+        let viewModel = CertPhotoCameraViewModel(
+            navigation: self,
+            goal: goal,
+            repository: repository
+        )
         let viewController = CertPhotoCameraViewController(viewModel: viewModel)
         viewController.modalPresentationStyle = .overFullScreen
         

--- a/rabit/rabit/PhotoEdit/PhotoEditViewController.swift
+++ b/rabit/rabit/PhotoEdit/PhotoEditViewController.swift
@@ -108,7 +108,7 @@ private extension PhotoEditViewController {
         )
 
         let updatedPhotoImage = viewModel.selectedPhotoData
-            .map(\.imageData)
+            .compactMap(\.imageData)
             .compactMap {
                 $0.toDownsampledCGImage(
                     pointSize: imageSize,

--- a/rabit/rabit/PhotoEdit/StyleSelect/Views/StyleSelectCell.swift
+++ b/rabit/rabit/PhotoEdit/StyleSelect/Views/StyleSelectCell.swift
@@ -69,8 +69,13 @@ final class StyleSelectCell: UICollectionViewCell {
         )
 
         DispatchQueue.global(qos: .userInteractive).async {
-            guard let downsampledCGImage = photo.imageData
-                .toDownsampledCGImage(pointSize: imageSize, scale: 2.0) else { return }
+            guard let imageData = photo.imageData,
+                  let downsampledCGImage = imageData
+                    .toDownsampledCGImage(
+                        pointSize: imageSize,
+                        scale: 2.0
+                    ) else { return }
+            
             let downsampledUIImage = UIImage(cgImage: downsampledCGImage)
 
             DispatchQueue.main.async {

--- a/rabit/rabit/Utilities/UIImage + Utils.swift
+++ b/rabit/rabit/Utilities/UIImage + Utils.swift
@@ -51,11 +51,9 @@ extension UIImage {
             range: (text as NSString).range(of: text)
         )
         
-        let image = UIImage(data: photo.imageData) ?? UIImage()
-        
         UIGraphicsBeginImageContextWithOptions(imageSize, false, 1.0)
         
-        image.draw(in: CGRect(origin: .zero, size: imageSize))
+        self.draw(in: CGRect(origin: .zero, size: imageSize))
         
         let label = UILabel()
         label.numberOfLines = 0


### PR DESCRIPTION
- DB(Realm)에 이미지를 형변환한 Data 타입의 데이터를 올리는 것은 적합하지 않다고하여, 이미지를 저장하고 불러오는 위치를 변경하고자 했습니다.

- 가장 먼저 이미지를 디바이스의 로컬인 "디스크 캐시"에 저장하는 방법을 사용했습니다.
    그리고 기존에 Realm에서 받아온 데이터를 ViewModel에서 사용하기 위한 `Photo` 모델 타입에 기존에 있던 `imageData: Data` 타입의 프로퍼티를 제거하고, 디스크 캐시에 저장된 이미지의 이름을 저장할 `imageName: String` 타입의 프로퍼티를 추가했습니다.


- 이렇게 할 경우, 가장 신경이 쓰였던 부분은 AlbumViewController에서 사용하는 AlbumCell에서 이미지를 불러올 때 어떤 방식을 사용할 것인지에 대한 부분이었습니다.

- AlbumCell에서 직접 어느 Repository에 접근하여 이미지를 Load해오는 방향은 View의 역할을 벗어나기 때문에, AlbumCellViewModel을 처음에 만들어서 사용했습니다.
    하지만 AlbumCellViewModel이 존재할 경우, UICollectionView에서 DataSource를 사용할 때 이점을 얻기 위해 사용한 RxDataSource 라이브러리가 의미없어졌습니다. Cell이 더이상 DataSource가 아닌 ViewModel을 바라보고 있기 때문입니다.


- 따라서 AlbumCellViewModel을 사용하지 않고, AlbumRespository에서 `Photo` 모델 타입을 Fetch해 온 다음 반환하는 로직을 조금 변경하는 방법을 사용했습니다.
    수정한 Photo 모델 타입에 의해 처음 Fetch해온 Photo 모델에는 Image에 대한 데이터는 imageName뿐 입니다. 따라서 이 imageName을 이용해 이미지를 디스크 캐시로부터 Load해오는 로직을 추가하고, Photo 모델에는 이미지 데이터를 저장할 수 있는 `imageData: Data?` 프로퍼티를 추가했습니다.
    `imageData` 프로퍼티가 Optional 타입이기 때문에 DB에는 따로 저장할 필요가 없고, AlbumRepository를 사용하는 여러 모듈들에서는 이미지 데이터를 가지고 있는 모델 타입을 사용할 수 있도록 했습니다.

- 그리고 이미지를 "저장"하는 ViewModel은 `CertPhotoCameraViewModel`만 존재하도록 했습니다.
    처음 설계대로, 실제 이미지에는 아무런 Text가 추가되어 있지 않기 때문에 처음 사진 찍었을 때만 이미지를 저장하고, 나머지 View들에서는 Photo 모델의 다른 프로퍼티를 토대로 새로운 Text를 이미지에 덧붙여 그리기만 하면 되기 때문에 기존에 찍었던 사진을 계속 이용할 것이기 때문입니다.
    
    